### PR TITLE
Fix opaque peer_id_t in tests

### DIFF
--- a/tests/host/test_event_deepcopy_free.c
+++ b/tests/host/test_event_deepcopy_free.c
@@ -7,17 +7,10 @@
 #include "libp2p/events.h"
 #include "peer_id/peer_id.h"
 
-static peer_id_t make_dummy_peer(void)
+static peer_id_t *make_dummy_peer(void)
 {
-    peer_id_t pid = {0};
-    pid.size = 3;
-    pid.bytes = (uint8_t *)malloc(pid.size);
-    if (pid.bytes)
-    {
-        pid.bytes[0] = 1;
-        pid.bytes[1] = 2;
-        pid.bytes[2] = 3;
-    }
+    peer_id_t *pid = NULL;
+    peer_id_new_from_text("12D3KooWQ7W3zfBDSSY5YTbSsfXCMVvjJAnYXhYzu3PV6PvJkU8E", &pid);
     return pid;
 }
 
@@ -54,7 +47,7 @@ int main(void)
     }
 
     /* Prepare a dummy peer for events that include peer IDs */
-    peer_id_t pid = make_dummy_peer();
+    peer_id_t *pid = make_dummy_peer();
 
     /* 1) LISTEN_ADDR_ADDED */
     {
@@ -99,7 +92,7 @@ int main(void)
         const char *addr = "/ip4/127.0.0.1/tcp/4001";
         libp2p_event_t e = {0};
         e.kind = LIBP2P_EVT_DIALING;
-        e.u.dialing.peer = &pid;
+        e.u.dialing.peer = pid;
         e.u.dialing.addr = addr;
         libp2p_event_publish(h, &e);
 
@@ -108,7 +101,7 @@ int main(void)
             goto fail;
         if (!got.u.dialing.peer || !got.u.dialing.addr)
         { libp2p_event_free(&got); goto fail; }
-        if (got.u.dialing.peer == &pid || got.u.dialing.addr == addr)
+        if (got.u.dialing.peer == pid || got.u.dialing.addr == addr)
         { libp2p_event_free(&got); goto fail; }
         libp2p_event_free(&got);
         if (got.u.dialing.peer || got.u.dialing.addr)
@@ -120,7 +113,7 @@ int main(void)
         const char *msg = "connect failed";
         libp2p_event_t e = {0};
         e.kind = LIBP2P_EVT_OUTGOING_CONNECTION_ERROR;
-        e.u.outgoing_conn_error.peer = &pid;
+        e.u.outgoing_conn_error.peer = pid;
         e.u.outgoing_conn_error.code = -1;
         e.u.outgoing_conn_error.msg = msg;
         libp2p_event_publish(h, &e);
@@ -130,7 +123,7 @@ int main(void)
             goto fail;
         if (!got.u.outgoing_conn_error.peer || !got.u.outgoing_conn_error.msg)
         { libp2p_event_free(&got); goto fail; }
-        if (got.u.outgoing_conn_error.peer == &pid || got.u.outgoing_conn_error.msg == msg)
+        if (got.u.outgoing_conn_error.peer == pid || got.u.outgoing_conn_error.msg == msg)
         { libp2p_event_free(&got); goto fail; }
         libp2p_event_free(&got);
         if (got.u.outgoing_conn_error.peer || got.u.outgoing_conn_error.msg)
@@ -160,7 +153,7 @@ int main(void)
         const char *addr = "/ip4/203.0.113.1/tcp/4001";
         libp2p_event_t e = {0};
         e.kind = LIBP2P_EVT_NEW_EXTERNAL_ADDR_OF_PEER;
-        e.u.new_external_addr_of_peer.peer = &pid;
+        e.u.new_external_addr_of_peer.peer = pid;
         e.u.new_external_addr_of_peer.addr = addr;
         libp2p_event_publish(h, &e);
 
@@ -169,7 +162,7 @@ int main(void)
             goto fail;
         if (!got.u.new_external_addr_of_peer.peer || !got.u.new_external_addr_of_peer.addr)
         { libp2p_event_free(&got); goto fail; }
-        if (got.u.new_external_addr_of_peer.peer == &pid || got.u.new_external_addr_of_peer.addr == addr)
+        if (got.u.new_external_addr_of_peer.peer == pid || got.u.new_external_addr_of_peer.addr == addr)
         { libp2p_event_free(&got); goto fail; }
         libp2p_event_free(&got);
         if (got.u.new_external_addr_of_peer.peer || got.u.new_external_addr_of_peer.addr)
@@ -181,7 +174,7 @@ int main(void)
         const char *addr = "/ip4/127.0.0.1/tcp/4002";
         libp2p_event_t e = {0};
         e.kind = LIBP2P_EVT_CONN_OPENED;
-        e.u.conn_opened.peer = &pid;
+        e.u.conn_opened.peer = pid;
         e.u.conn_opened.addr = addr;
         e.u.conn_opened.inbound = 0;
         libp2p_event_publish(h, &e);
@@ -191,7 +184,7 @@ int main(void)
             goto fail;
         if (!got.u.conn_opened.peer || !got.u.conn_opened.addr)
         { libp2p_event_free(&got); goto fail; }
-        if (got.u.conn_opened.peer == &pid || got.u.conn_opened.addr == addr)
+        if (got.u.conn_opened.peer == pid || got.u.conn_opened.addr == addr)
         { libp2p_event_free(&got); goto fail; }
         libp2p_event_free(&got);
         if (got.u.conn_opened.peer || got.u.conn_opened.addr)
@@ -202,7 +195,7 @@ int main(void)
     {
         libp2p_event_t e = {0};
         e.kind = LIBP2P_EVT_CONN_CLOSED;
-        e.u.conn_closed.peer = &pid;
+        e.u.conn_closed.peer = pid;
         e.u.conn_closed.reason = 0;
         libp2p_event_publish(h, &e);
 
@@ -211,7 +204,7 @@ int main(void)
             goto fail;
         if (!got.u.conn_closed.peer)
         { libp2p_event_free(&got); goto fail; }
-        if (got.u.conn_closed.peer == &pid)
+        if (got.u.conn_closed.peer == pid)
         { libp2p_event_free(&got); goto fail; }
         libp2p_event_free(&got);
         if (got.u.conn_closed.peer)
@@ -242,7 +235,7 @@ int main(void)
         libp2p_event_t e = {0};
         e.kind = LIBP2P_EVT_STREAM_OPENED;
         e.u.stream_opened.protocol_id = pid_str;
-        e.u.stream_opened.peer = &pid;
+        e.u.stream_opened.peer = pid;
         e.u.stream_opened.initiator = 1;
         libp2p_event_publish(h, &e);
 
@@ -251,7 +244,7 @@ int main(void)
             goto fail;
         if (!got.u.stream_opened.peer || !got.u.stream_opened.protocol_id)
         { libp2p_event_free(&got); goto fail; }
-        if (got.u.stream_opened.peer == &pid || got.u.stream_opened.protocol_id == pid_str)
+        if (got.u.stream_opened.peer == pid || got.u.stream_opened.protocol_id == pid_str)
         { libp2p_event_free(&got); goto fail; }
         libp2p_event_free(&got);
         if (got.u.stream_opened.peer || got.u.stream_opened.protocol_id)
@@ -278,15 +271,13 @@ int main(void)
     }
 
     /* cleanup */
-    if (pid.bytes)
-        free(pid.bytes);
+    peer_id_free(pid);
     libp2p_host_free(h);
     libp2p_host_builder_free(b);
     return 0;
 
 fail:
-    if (pid.bytes)
-        free(pid.bytes);
+    peer_id_free(pid);
     libp2p_host_free(h);
     libp2p_host_builder_free(b);
     return 1;

--- a/tests/host/test_host_identity.c
+++ b/tests/host/test_host_identity.c
@@ -68,7 +68,7 @@ int main(void)
 		return 1;
 	}
 
-	peer_id_t expected = {0};
+	peer_id_t *expected = NULL;
 	if (peer_id_new_from_private_key_pb(sk, sk_len, &expected) != PEER_ID_OK)
 	{
 		fprintf(stderr, "peer_id_new_from_private_key_pb failed\n");
@@ -79,25 +79,21 @@ int main(void)
 
 	peer_id_t *got = NULL;
 	rc = libp2p_host_get_peer_id(host, &got);
-	int ok = (rc == 0 && got && got->bytes && got->size > 0);
+	int ok = (rc == 0 && got != NULL);
 	print_result("host_get_peer_id", ok);
 	if (!ok)
 		failures++;
 
 	if (ok)
 	{
-		int eq = peer_id_equal(&expected, got);
+		int eq = peer_id_equal(expected, got);
 		print_result("host_peer_id_matches_expected", eq == 1);
 		if (eq != 1)
 			failures++;
 	}
 
-	if (got)
-	{
-		peer_id_free(got);
-		free(got);
-	}
-	peer_id_free(&expected);
+	peer_id_free(got);
+	peer_id_free(expected);
 	free(sk);
 	libp2p_host_free(host);
 	return failures ? 1 : 0;

--- a/tests/host/test_identify_control_api.c
+++ b/tests/host/test_identify_control_api.c
@@ -137,7 +137,6 @@ int main(void)
 	if (libp2p_identify_new(ha, &opts, &ids) != 0 || !ids)
 	{
 		peer_id_free(pidB);
-		free(pidB);
 		return 1;
 	}
 
@@ -146,7 +145,6 @@ int main(void)
 	{
 		libp2p_identify_ctrl_free(ids);
 		peer_id_free(pidB);
-		free(pidB);
 		libp2p_host_stop(ha);
 		libp2p_host_stop(hb);
 		libp2p_host_free(ha);
@@ -192,7 +190,6 @@ int main(void)
 	libp2p_host_free_peer_protocols(protos, n);
 	libp2p_identify_ctrl_free(ids);
 	peer_id_free(pidB);
-	free(pidB);
 	libp2p_host_stop(ha);
 	libp2p_host_stop(hb);
 	libp2p_host_free(ha);

--- a/tests/host/test_identify_push_publish.c
+++ b/tests/host/test_identify_push_publish.c
@@ -195,7 +195,6 @@ int main(void)
 	if (!protocols_update_waiter_start(&proto_waiter, hb, pidA, "[TEST_PUB]"))
 	{
 		peer_id_free(pidA);
-		free(pidA);
 		return 1;
 	}
 
@@ -266,7 +265,6 @@ int main(void)
 	if (pidA)
 	{
 		peer_id_free(pidA);
-		free(pidA);
 	}
 	fprintf(stderr, "[TEST_PUB] stopping hosts\n");
 	if (ping_srv)

--- a/tests/host/test_identify_push_reception.c
+++ b/tests/host/test_identify_push_reception.c
@@ -275,7 +275,6 @@ int main(void)
 		if (pidA)
 		{
 			peer_id_free(pidA);
-			free(pidA);
 		}
 		return 1;
 	}
@@ -289,7 +288,6 @@ int main(void)
 		if (pidA)
 		{
 			peer_id_free(pidA);
-			free(pidA);
 		}
 		return 1;
 	}
@@ -329,7 +327,6 @@ int main(void)
 	if (pidA)
 	{
 		peer_id_free(pidA);
-		free(pidA);
 	}
 	fprintf(stderr, "[TEST_RCV] stopping hosts\n");
 	libp2p_host_stop(hb);

--- a/tests/host/test_quic_host_dial_upgrade.c
+++ b/tests/host/test_quic_host_dial_upgrade.c
@@ -95,16 +95,10 @@ static libp2p_transport_err_t stub_quic_dial(libp2p_transport_t *self, const mul
 		return LIBP2P_TRANSPORT_ERR_INTERNAL;
 	session->owner = ctx;
 
-	peer_id_t *peer = (peer_id_t *)calloc(1, sizeof(*peer));
-	if (!peer)
-	{
-		free(session);
-		return LIBP2P_TRANSPORT_ERR_INTERNAL;
-	}
-	if (peer_id_new_from_text("12D3KooWQ7W3zfBDSSY5YTbSsfXCMVvjJAnYXhYzu3PV6PvJkU8E", peer) != PEER_ID_OK)
+	peer_id_t *peer = NULL;
+	if (peer_id_new_from_text("12D3KooWQ7W3zfBDSSY5YTbSsfXCMVvjJAnYXhYzu3PV6PvJkU8E", &peer) != PEER_ID_OK)
 	{
 		peer_id_free(peer);
-		free(peer);
 		free(session);
 		return LIBP2P_TRANSPORT_ERR_INTERNAL;
 	}
@@ -113,7 +107,6 @@ static libp2p_transport_err_t stub_quic_dial(libp2p_transport_t *self, const mul
 	if (!conn)
 	{
 		peer_id_free(peer);
-		free(peer);
 		free(session);
 		return LIBP2P_TRANSPORT_ERR_INTERNAL;
 	}
@@ -383,7 +376,7 @@ int main(void)
 		libp2p_host_free(host);
 		return fail_msg("remote peer missing");
 	}
-	peer_id_t expected_peer = {0};
+	peer_id_t *expected_peer = NULL;
 	if (peer_id_new_from_text("12D3KooWQ7W3zfBDSSY5YTbSsfXCMVvjJAnYXhYzu3PV6PvJkU8E", &expected_peer) != PEER_ID_OK)
 	{
 		libp2p_stream_close(cb_state.stream);
@@ -392,8 +385,8 @@ int main(void)
 		libp2p_host_free(host);
 		return fail_msg("expected peer parse failed");
 	}
-	int same_peer = peer_id_equal(rpeer, &expected_peer);
-	peer_id_free(&expected_peer);
+	int same_peer = peer_id_equal(rpeer, expected_peer);
+	peer_id_free(expected_peer);
 	if (same_peer != 1)
 	{
 		libp2p_stream_close(cb_state.stream);

--- a/tests/host/test_quic_host_stream_exchange.c
+++ b/tests/host/test_quic_host_stream_exchange.c
@@ -314,12 +314,10 @@ cleanup:
 	if (client_peer)
 	{
 		peer_id_free(client_peer);
-		free(client_peer);
 	}
 	if (server_peer)
 	{
 		peer_id_free(server_peer);
-		free(server_peer);
 	}
 	if (client)
 		libp2p_host_free(client);

--- a/tests/host/test_quic_incoming_error_events.c
+++ b/tests/host/test_quic_incoming_error_events.c
@@ -84,17 +84,9 @@ int main(void)
 		return 1;
 	}
 
-	peer_id_t *conn_peer = (peer_id_t *)calloc(1, sizeof(*conn_peer));
-	if (!conn_peer)
+	peer_id_t *conn_peer = NULL;
+	if (peer_id_new_from_text("12D3KooWSgVg7Ha9r8wB6L6scR8Db1wUwYUyJYEdpjXD2qH5A5X9", &conn_peer) != PEER_ID_OK)
 	{
-		free(session);
-		libp2p_host_free(host);
-		return 1;
-	}
-	if (peer_id_new_from_text("12D3KooWSgVg7Ha9r8wB6L6scR8Db1wUwYUyJYEdpjXD2qH5A5X9", conn_peer) != PEER_ID_OK)
-	{
-		peer_id_free(conn_peer);
-		free(conn_peer);
 		free(session);
 		libp2p_host_free(host);
 		return 1;
@@ -108,7 +100,6 @@ int main(void)
 	{
 		libp2p__host_set_quic_muxer_factory(NULL);
 		peer_id_free(conn_peer);
-		free(conn_peer);
 		free(session);
 		libp2p_host_free(host);
 		return 1;

--- a/tests/host/test_quic_listener_accept.c
+++ b/tests/host/test_quic_listener_accept.c
@@ -168,7 +168,7 @@ int main(void)
 		return 1;
 	}
 
-	peer_id_t expected_peer = {0};
+	peer_id_t *expected_peer = NULL;
 	if (peer_id_new_from_text("12D3KooWSgVg7Ha9r8wB6L6scR8Db1wUwYUyJYEdpjXD2qH5A5X9", &expected_peer) != PEER_ID_OK)
 	{
 		multiaddr_free(local_addr);
@@ -179,21 +179,10 @@ int main(void)
 		return 1;
 	}
 
-	peer_id_t *conn_peer = (peer_id_t *)calloc(1, sizeof(*conn_peer));
-	if (!conn_peer)
+	peer_id_t *conn_peer = NULL;
+	if (peer_id_new_from_text("12D3KooWSgVg7Ha9r8wB6L6scR8Db1wUwYUyJYEdpjXD2qH5A5X9", &conn_peer) != PEER_ID_OK)
 	{
-		peer_id_free(&expected_peer);
-		multiaddr_free(local_addr);
-		multiaddr_free(remote_addr);
-		free(session);
-		libp2p__host_set_quic_muxer_factory(NULL);
-		libp2p_host_free(host);
-		return 1;
-	}
-	if (peer_id_new_from_text("12D3KooWSgVg7Ha9r8wB6L6scR8Db1wUwYUyJYEdpjXD2qH5A5X9", conn_peer) != PEER_ID_OK)
-	{
-		peer_id_free(&expected_peer);
-		free(conn_peer);
+		peer_id_free(expected_peer);
 		multiaddr_free(local_addr);
 		multiaddr_free(remote_addr);
 		free(session);
@@ -206,7 +195,7 @@ int main(void)
 						   stub_session_free, conn_peer);
 	if (!conn)
 	{
-		peer_id_free(&expected_peer);
+		peer_id_free(expected_peer);
 		multiaddr_free(local_addr);
 		multiaddr_free(remote_addr);
 		libp2p__host_set_quic_muxer_factory(NULL);
@@ -220,7 +209,7 @@ int main(void)
 	if (!ok || !uc)
 	{
 		libp2p_conn_free(conn);
-		peer_id_free(&expected_peer);
+		peer_id_free(expected_peer);
 		multiaddr_free(remote_addr);
 		libp2p__host_set_quic_muxer_factory(NULL);
 		libp2p_host_free(host);
@@ -236,7 +225,7 @@ int main(void)
 	ok &= check(uc->remote_peer != NULL, "uconn remote peer set");
 	if (uc->remote_peer)
 	{
-		ok &= check(peer_id_equal(uc->remote_peer, &expected_peer) == 1, "remote peer matches expectation");
+		ok &= check(peer_id_equal(uc->remote_peer, expected_peer) == 1, "remote peer matches expectation");
 	}
 
 	ok &= check(uc->conn == conn, "uconn wraps original connection");
@@ -244,7 +233,6 @@ int main(void)
 
 	libp2p_muxer_free((libp2p_muxer_t *)uc->muxer);
 	peer_id_free(uc->remote_peer);
-	free(uc->remote_peer);
 	free(uc);
 	libp2p_conn_free(conn);
 
@@ -254,7 +242,7 @@ int main(void)
 	ok &= check(stub_muxer_free_called == 1, "muxer free called once");
 	ok &= check(session_free_called == 1, "session free invoked");
 
-	peer_id_free(&expected_peer);
+	peer_id_free(expected_peer);
 	libp2p__host_set_quic_muxer_factory(NULL);
 	libp2p_host_free(host);
 	return ok ? 0 : 1;

--- a/tests/host/test_quic_stream_loopback.c
+++ b/tests/host/test_quic_stream_loopback.c
@@ -640,7 +640,6 @@ cleanup:
 	if (expected_server_peer)
 	{
 		peer_id_free(expected_server_peer);
-		free(expected_server_peer);
 	}
 
 	if (server_ctx_inited)

--- a/tests/host/test_quic_upgrade_outbound.c
+++ b/tests/host/test_quic_upgrade_outbound.c
@@ -159,7 +159,7 @@ int main(void)
 		return 1;
 	}
 
-	peer_id_t expected_peer = {0};
+	peer_id_t *expected_peer = NULL;
 	if (peer_id_new_from_text("12D3KooWQ7W3zfBDSSY5YTbSsfXCMVvjJAnYXhYzu3PV6PvJkU8E", &expected_peer) != PEER_ID_OK)
 	{
 		multiaddr_free(remote_addr);
@@ -169,20 +169,10 @@ int main(void)
 		return 1;
 	}
 
-	peer_id_t *conn_peer = (peer_id_t *)calloc(1, sizeof(*conn_peer));
-	if (!conn_peer)
+	peer_id_t *conn_peer = NULL;
+	if (peer_id_new_from_text("12D3KooWQ7W3zfBDSSY5YTbSsfXCMVvjJAnYXhYzu3PV6PvJkU8E", &conn_peer) != PEER_ID_OK)
 	{
-		peer_id_free(&expected_peer);
-		multiaddr_free(remote_addr);
-		free(session);
-		libp2p__host_set_quic_muxer_factory(NULL);
-		libp2p_host_free(host);
-		return 1;
-	}
-	if (peer_id_new_from_text("12D3KooWQ7W3zfBDSSY5YTbSsfXCMVvjJAnYXhYzu3PV6PvJkU8E", conn_peer) != PEER_ID_OK)
-	{
-		peer_id_free(&expected_peer);
-		free(conn_peer);
+		peer_id_free(expected_peer);
 		multiaddr_free(remote_addr);
 		free(session);
 		libp2p__host_set_quic_muxer_factory(NULL);
@@ -194,7 +184,7 @@ int main(void)
 		libp2p_quic_conn_new(NULL, remote_addr, session, stub_session_close, stub_session_free, conn_peer);
 	if (!conn)
 	{
-		peer_id_free(&expected_peer);
+		peer_id_free(expected_peer);
 		multiaddr_free(remote_addr);
 		libp2p__host_set_quic_muxer_factory(NULL);
 		libp2p_host_free(host);
@@ -207,7 +197,7 @@ int main(void)
 	if (!ok || !uc)
 	{
 		libp2p_conn_free(conn);
-		peer_id_free(&expected_peer);
+		peer_id_free(expected_peer);
 		multiaddr_free(remote_addr);
 		libp2p__host_set_quic_muxer_factory(NULL);
 		libp2p_host_free(host);
@@ -221,7 +211,7 @@ int main(void)
 	ok &= check(uc->remote_peer != NULL, "uc remote peer non-null");
 	ok &= check(uc->remote_peer != conn_peer, "remote peer cloned");
 	if (uc->remote_peer)
-		ok &= check(peer_id_equal(&expected_peer, uc->remote_peer) == 1, "remote peer matches input");
+		ok &= check(peer_id_equal(expected_peer, uc->remote_peer) == 1, "remote peer matches input");
 
 	ok &= check(uc->muxer != NULL, "muxer populated");
 
@@ -244,7 +234,6 @@ int main(void)
 	if (uc->remote_peer)
 	{
 		peer_id_free(uc->remote_peer);
-		free(uc->remote_peer);
 		uc->remote_peer = NULL;
 	}
 	libp2p_conn_free(uc->conn);
@@ -252,7 +241,7 @@ int main(void)
 
 	ok &= check(session_free_called == 1, "session free called once");
 
-	peer_id_free(&expected_peer);
+	peer_id_free(expected_peer);
 	multiaddr_free(remote_addr);
 
 	libp2p__host_set_quic_muxer_factory(NULL);

--- a/tests/protocol/gossipsub/test_gossipsub_service_common.c
+++ b/tests/protocol/gossipsub/test_gossipsub_service_common.c
@@ -181,12 +181,12 @@ int decode_prune_px_count(const uint8_t *frame, size_t frame_len, const char *to
 	return match_found;
 }
 
-int setup_gossip_peer(libp2p_gossipsub_t *gs, const char *topic, const char *peer_str, peer_id_t *out_peer)
+int setup_gossip_peer(libp2p_gossipsub_t *gs, const char *topic, const char *peer_str, peer_id_t **out_peer)
 {
 	if (!gs || !topic || !peer_str || !out_peer)
 		return 0;
 
-	memset(out_peer, 0, sizeof(*out_peer));
+	*out_peer = NULL;
 	if (peer_id_new_from_text(peer_str, out_peer) != PEER_ID_OK)
 		return 0;
 
@@ -195,32 +195,35 @@ int setup_gossip_peer(libp2p_gossipsub_t *gs, const char *topic, const char *pee
 	libp2p_err_t enc_rc = encode_subscription_rpc(topic, 1, &frame, &frame_len);
 	if (enc_rc != LIBP2P_ERR_OK || !frame || frame_len == 0)
 	{
-		peer_id_free(out_peer);
+		peer_id_free(*out_peer);
+		*out_peer = NULL;
 		if (frame)
 			free(frame);
 		return 0;
 	}
 
-	libp2p_err_t inj_rc = libp2p_gossipsub__inject_frame(gs, out_peer, frame, frame_len);
+	libp2p_err_t inj_rc = libp2p_gossipsub__inject_frame(gs, *out_peer, frame, frame_len);
 	free(frame);
 	if (inj_rc != LIBP2P_ERR_OK)
 	{
-		peer_id_free(out_peer);
+		peer_id_free(*out_peer);
+		*out_peer = NULL;
 		return 0;
 	}
 
-	libp2p_err_t conn_rc = libp2p_gossipsub__peer_set_connected(gs, out_peer, 1);
+	libp2p_err_t conn_rc = libp2p_gossipsub__peer_set_connected(gs, *out_peer, 1);
 	if (conn_rc != LIBP2P_ERR_OK)
 	{
-		peer_id_free(out_peer);
+		peer_id_free(*out_peer);
+		*out_peer = NULL;
 		return 0;
 	}
 
-	(void)libp2p_gossipsub__peer_clear_sendq(gs, out_peer);
+	(void)libp2p_gossipsub__peer_clear_sendq(gs, *out_peer);
 	return 1;
 }
 
-int run_gossip_factor_scenario(libp2p_gossipsub_t *gs, const char *topic, peer_id_t *peers, size_t count,
+int run_gossip_factor_scenario(libp2p_gossipsub_t *gs, const char *topic, peer_id_t **peers, size_t count,
 			       const uint8_t *payload, size_t payload_len, size_t expected, size_t *out_selected,
 			       size_t *out_limit)
 {
@@ -241,7 +244,7 @@ int run_gossip_factor_scenario(libp2p_gossipsub_t *gs, const char *topic, peer_i
 
 	usleep(10000);
 	for (size_t i = 0; i < count; ++i)
-		(void)libp2p_gossipsub__peer_clear_sendq(gs, &peers[i]);
+		(void)libp2p_gossipsub__peer_clear_sendq(gs, peers[i]);
 
 	if (libp2p_gossipsub__heartbeat(gs) != LIBP2P_ERR_OK)
 		return 0;
@@ -256,7 +259,7 @@ int run_gossip_factor_scenario(libp2p_gossipsub_t *gs, const char *topic, peer_i
 		queue_shape_ok = 1;
 		for (size_t i = 0; i < count; ++i)
 		{
-			size_t qlen = libp2p_gossipsub__peer_sendq_len(gs, &peers[i]);
+			size_t qlen = libp2p_gossipsub__peer_sendq_len(gs, peers[i]);
 			if (qlen > 0)
 			{
 				if (qlen != 1)
@@ -553,9 +556,12 @@ static libp2p_err_t build_peer_record_unsigned(const uint8_t *payload_type, size
 static int peer_record_write_fields(NoiseProtobuf *pbuf, const peer_id_t *peer, const multiaddr_t *const *addrs,
 				    size_t addr_count)
 {
-	if (!pbuf || !peer || !peer->bytes || peer->size == 0)
+	const uint8_t *peer_mh = NULL;
+	size_t peer_mh_len = 0;
+	if (!pbuf || !peer || peer_id_multihash_view(peer, &peer_mh, &peer_mh_len) != PEER_ID_OK ||
+	    !peer_mh || peer_mh_len == 0)
 		return 0;
-	if (noise_protobuf_write_bytes(pbuf, 1, peer->bytes, peer->size) != NOISE_ERROR_NONE)
+	if (noise_protobuf_write_bytes(pbuf, 1, peer_mh, peer_mh_len) != NOISE_ERROR_NONE)
 		return 0;
 	if (noise_protobuf_write_uint64(pbuf, 2, 1) != NOISE_ERROR_NONE)
 		return 0;
@@ -667,14 +673,14 @@ libp2p_err_t encode_signed_peer_record(const peer_id_t *peer, const multiaddr_t 
 
 	if (peer)
 	{
-		peer_id_t derived = {0};
+		peer_id_t *derived = NULL;
 		if (peer_id_new_from_public_key_pb(pubkey_pb, pubkey_pb_len, &derived) != PEER_ID_OK)
 		{
-			peer_id_free(&derived);
+			peer_id_free(derived);
 			goto cleanup;
 		}
-		int equal = peer_id_equal(peer, &derived);
-		peer_id_free(&derived);
+		int equal = peer_id_equal(peer, derived);
+		peer_id_free(derived);
 		if (!equal)
 		{
 			result = LIBP2P_ERR_UNSUPPORTED;
@@ -756,7 +762,10 @@ cleanup:
 libp2p_err_t encode_prune_px_rpc(const char *topic, const peer_id_t *px_peer, const uint8_t *signed_record,
 				 size_t signed_record_len, uint8_t **out_buf, size_t *out_len)
 {
-	if (!topic || !px_peer || !px_peer->bytes || px_peer->size == 0 || !out_buf || !out_len)
+	const uint8_t *px_mh = NULL;
+	size_t px_mh_len = 0;
+	if (!topic || !px_peer || peer_id_multihash_view(px_peer, &px_mh, &px_mh_len) != PEER_ID_OK ||
+	    !px_mh || px_mh_len == 0 || !out_buf || !out_len)
 		return LIBP2P_ERR_NULL_PTR;
 	*out_buf = NULL;
 	*out_len = 0;
@@ -787,7 +796,7 @@ libp2p_err_t encode_prune_px_rpc(const char *topic, const peer_id_t *px_peer, co
 	if (noise_rc != NOISE_ERROR_NONE || !info)
 		goto cleanup;
 
-	noise_rc = libp2p_gossipsub_PeerInfo_set_peer_id(info, px_peer->bytes, px_peer->size);
+	noise_rc = libp2p_gossipsub_PeerInfo_set_peer_id(info, px_mh, px_mh_len);
 	if (noise_rc != NOISE_ERROR_NONE)
 		goto cleanup;
 
@@ -885,16 +894,19 @@ libp2p_err_t encode_prune_rpc(const char *topic, int include_px, uint8_t **out_b
 	if (include_px)
 	{
 		static const char *const px_peer_id = "12D3KooWMFFPRc3yLVaM76FUQojVKkD2VwGdMan3ZDV4SSQdlqzC";
-		peer_id_t px_peer = {0};
+		peer_id_t *px_peer = NULL;
 		if (peer_id_new_from_text(px_peer_id, &px_peer) == PEER_ID_OK)
 		{
+			const uint8_t *px_peer_mh = NULL;
+			size_t px_peer_mh_len = 0;
+			peer_id_multihash_view(px_peer, &px_peer_mh, &px_peer_mh_len);
 			libp2p_gossipsub_PeerInfo *px_info = NULL;
 			noise_rc = libp2p_gossipsub_ControlPrune_add_peers(prune, &px_info);
-			if (noise_rc == NOISE_ERROR_NONE && px_info)
+			if (noise_rc == NOISE_ERROR_NONE && px_info && px_peer_mh && px_peer_mh_len > 0)
 			{
-				noise_rc = libp2p_gossipsub_PeerInfo_set_peer_id(px_info, px_peer.bytes, px_peer.size);
+				noise_rc = libp2p_gossipsub_PeerInfo_set_peer_id(px_info, px_peer_mh, px_peer_mh_len);
 			}
-			peer_id_free(&px_peer);
+			peer_id_free(px_peer);
 			if (noise_rc != NOISE_ERROR_NONE)
 				goto cleanup;
 		}
@@ -1070,7 +1082,8 @@ void gossipsub_service_free_env(gossipsub_service_test_env_t *env)
 
 	if (env->config_peer_ok)
 	{
-		peer_id_free(&env->config_peer);
+		peer_id_free(env->config_peer);
+		env->config_peer = NULL;
 		env->config_peer_ok = 0;
 	}
 

--- a/tests/protocol/gossipsub/test_gossipsub_service_common.h
+++ b/tests/protocol/gossipsub/test_gossipsub_service_common.h
@@ -86,7 +86,7 @@ typedef struct gossipsub_service_test_env_s
 	int cfg_initialized;
 	const char *config_addrs[1];
 	libp2p_gossipsub_explicit_peer_t cfg_explicit_peer;
-	peer_id_t config_peer;
+	peer_id_t *config_peer;
 	int config_peer_ok;
 	int fatal_failure;
 	int score_update_count;
@@ -98,8 +98,8 @@ void print_result(const char *name, int ok);
 libp2p_err_t encode_subscription_rpc(const char *topic, int subscribe, uint8_t **out_buf, size_t *out_len);
 size_t compute_expected_gossip_targets(size_t eligible, int gossip_percent, int d_lazy);
 int decode_prune_px_count(const uint8_t *frame, size_t frame_len, const char *topic, size_t *out_px_count);
-int setup_gossip_peer(libp2p_gossipsub_t *gs, const char *topic, const char *peer_str, peer_id_t *out_peer);
-int run_gossip_factor_scenario(libp2p_gossipsub_t *gs, const char *topic, peer_id_t *peers, size_t count,
+int setup_gossip_peer(libp2p_gossipsub_t *gs, const char *topic, const char *peer_str, peer_id_t **out_peer);
+int run_gossip_factor_scenario(libp2p_gossipsub_t *gs, const char *topic, peer_id_t **peers, size_t count,
 			       const uint8_t *payload, size_t payload_len, size_t expected, size_t *out_selected,
 			       size_t *out_limit);
 libp2p_err_t encode_control_ihave_rpc(const char *topic, const uint8_t *msg_id, size_t msg_id_len, uint8_t **out_buf,

--- a/tests/protocol/gossipsub/test_gossipsub_service_explicit.c
+++ b/tests/protocol/gossipsub/test_gossipsub_service_explicit.c
@@ -12,8 +12,8 @@ int gossipsub_service_run_explicit_peer_tests(gossipsub_service_test_env_t *env)
 	const char *explicit_peer_str = "12D3KooWL9qw9QdCsiPUQXGWxZhwivKar35CFYuU9B9kavHuV2XZ";
 	const char *mesh_peer_str = "12D3KooWL41axLhXgML3zbxTDkVxFvtz7ZzZWtH1yurVpbkWueMH";
 	const char *explicit_topic_name = "explicit/test/topic";
-	peer_id_t explicit_peer = {0};
-	peer_id_t mesh_peer = {0};
+	peer_id_t *explicit_peer = NULL;
+	peer_id_t *mesh_peer = NULL;
 	int explicit_peer_ok = (peer_id_new_from_text(explicit_peer_str, &explicit_peer) == PEER_ID_OK);
 	int mesh_peer_ok = (peer_id_new_from_text(mesh_peer_str, &mesh_peer) == PEER_ID_OK);
 	print_result("gossipsub_explicit_peer_id", explicit_peer_ok);
@@ -35,7 +35,7 @@ int gossipsub_service_run_explicit_peer_tests(gossipsub_service_test_env_t *env)
 	if (explicit_peer_ok && mesh_peer_ok)
 	{
 		explicit_sub_rc = libp2p_gossipsub_subscribe(gs, &explicit_topic_cfg);
-		peering_rc = libp2p_gossipsub_peering_add(gs, &explicit_peer);
+		peering_rc = libp2p_gossipsub_peering_add(gs, explicit_peer);
 	}
 
 	explicit_sub_ok = (explicit_peer_ok && mesh_peer_ok && explicit_sub_rc == LIBP2P_ERR_OK);
@@ -50,24 +50,24 @@ int gossipsub_service_run_explicit_peer_tests(gossipsub_service_test_env_t *env)
 
 	if (explicit_sub_ok && peering_add_ok)
 	{
-		libp2p_err_t set_conn_rc = libp2p_gossipsub__peer_set_connected(gs, &explicit_peer, 1);
+		libp2p_err_t set_conn_rc = libp2p_gossipsub__peer_set_connected(gs, explicit_peer, 1);
 		int set_conn_ok = (set_conn_rc == LIBP2P_ERR_OK);
 		print_result("gossipsub_explicit_peer_mark_connected", set_conn_ok);
 		if (!set_conn_ok)
 			failures++;
 
 		libp2p_err_t mesh_add_rc =
-			libp2p_gossipsub__topic_mesh_add_peer(gs, explicit_topic_name, &mesh_peer, 1);
+			libp2p_gossipsub__topic_mesh_add_peer(gs, explicit_topic_name, mesh_peer, 1);
 		int mesh_add_ok = (mesh_add_rc == LIBP2P_ERR_OK);
 		print_result("gossipsub_explicit_mesh_peer_added", mesh_add_ok);
 		if (!mesh_add_ok)
 			failures++;
 
 		if (mesh_add_ok)
-			(void)libp2p_gossipsub__peer_set_connected(gs, &mesh_peer, 1);
+			(void)libp2p_gossipsub__peer_set_connected(gs, mesh_peer, 1);
 
 		int explicit_in_mesh =
-			libp2p_gossipsub__topic_mesh_contains(gs, explicit_topic_name, &explicit_peer, NULL, NULL);
+			libp2p_gossipsub__topic_mesh_contains(gs, explicit_topic_name, explicit_peer, NULL, NULL);
 		int explicit_not_mesh = (explicit_in_mesh == 0);
 		print_result("gossipsub_explicit_peer_not_in_mesh", explicit_not_mesh);
 		if (!explicit_not_mesh)
@@ -94,7 +94,7 @@ int gossipsub_service_run_explicit_peer_tests(gossipsub_service_test_env_t *env)
 			size_t explicit_queue = 0;
 			for (int i = 0; i < 200 && explicit_queue == 0; ++i)
 			{
-				explicit_queue = libp2p_gossipsub__peer_sendq_len(gs, &explicit_peer);
+				explicit_queue = libp2p_gossipsub__peer_sendq_len(gs, explicit_peer);
 				if (explicit_queue == 0)
 					usleep(1000);
 			}
@@ -107,7 +107,7 @@ int gossipsub_service_run_explicit_peer_tests(gossipsub_service_test_env_t *env)
 			{
 				uint8_t *queued_frame = NULL;
 				size_t queued_len = 0;
-				libp2p_err_t pop_rc = libp2p_gossipsub__peer_pop_sendq(gs, &explicit_peer,
+				libp2p_err_t pop_rc = libp2p_gossipsub__peer_pop_sendq(gs, explicit_peer,
 										       &queued_frame, &queued_len);
 				int pop_ok = (pop_rc == LIBP2P_ERR_OK && queued_frame && queued_len);
 				print_result("gossipsub_explicit_peer_pop_publish", pop_ok);
@@ -128,7 +128,7 @@ int gossipsub_service_run_explicit_peer_tests(gossipsub_service_test_env_t *env)
 
 		libp2p_err_t graft_inj_rc = LIBP2P_ERR_INTERNAL;
 		if (graft_enc_ok)
-			graft_inj_rc = libp2p_gossipsub__inject_frame(gs, &explicit_peer, graft_frame, graft_len);
+			graft_inj_rc = libp2p_gossipsub__inject_frame(gs, explicit_peer, graft_frame, graft_len);
 		int graft_inj_ok = (graft_enc_ok && graft_inj_rc == LIBP2P_ERR_OK);
 		print_result("gossipsub_explicit_graft_inject", graft_inj_ok);
 		if (!graft_inj_ok)
@@ -136,7 +136,7 @@ int gossipsub_service_run_explicit_peer_tests(gossipsub_service_test_env_t *env)
 		if (graft_frame)
 			free(graft_frame);
 
-		size_t queue_after_graft = libp2p_gossipsub__peer_sendq_len(gs, &explicit_peer);
+		size_t queue_after_graft = libp2p_gossipsub__peer_sendq_len(gs, explicit_peer);
 		int no_prune = (queue_after_graft == 0);
 		print_result("gossipsub_explicit_graft_does_not_enqueue", no_prune);
 		if (!no_prune)
@@ -146,30 +146,30 @@ int gossipsub_service_run_explicit_peer_tests(gossipsub_service_test_env_t *env)
 			{
 				uint8_t *tmp_buf = NULL;
 				size_t tmp_len = 0;
-				libp2p_gossipsub__peer_pop_sendq(gs, &explicit_peer, &tmp_buf, &tmp_len);
+				libp2p_gossipsub__peer_pop_sendq(gs, explicit_peer, &tmp_buf, &tmp_len);
 				if (tmp_buf)
 					free(tmp_buf);
-				queue_after_graft = libp2p_gossipsub__peer_sendq_len(gs, &explicit_peer);
+				queue_after_graft = libp2p_gossipsub__peer_sendq_len(gs, explicit_peer);
 			}
 		}
 
 		libp2p_event_t close_evt;
 		memset(&close_evt, 0, sizeof(close_evt));
 		close_evt.kind = LIBP2P_EVT_CONN_CLOSED;
-		close_evt.u.conn_closed.peer = &explicit_peer;
+		close_evt.u.conn_closed.peer = explicit_peer;
 		close_evt.u.conn_closed.reason = 0;
 		gossipsub_host_events_on_host_event(&close_evt, gs);
 
-		int timer_id = libp2p_gossipsub__peer_explicit_timer_id(gs, &explicit_peer);
+		int timer_id = libp2p_gossipsub__peer_explicit_timer_id(gs, explicit_peer);
 		int timer_scheduled = (timer_id > 0);
 		print_result("gossipsub_explicit_redial_scheduled", timer_scheduled);
 		if (!timer_scheduled)
 			failures++;
 
-		(void)libp2p_gossipsub_peering_remove(gs, &explicit_peer);
-		(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, explicit_topic_name, &mesh_peer);
-		(void)libp2p_gossipsub__peer_clear_sendq(gs, &explicit_peer);
-		(void)libp2p_gossipsub__peer_clear_sendq(gs, &mesh_peer);
+		(void)libp2p_gossipsub_peering_remove(gs, explicit_peer);
+		(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, explicit_topic_name, mesh_peer);
+		(void)libp2p_gossipsub__peer_clear_sendq(gs, explicit_peer);
+		(void)libp2p_gossipsub__peer_clear_sendq(gs, mesh_peer);
 		libp2p_err_t explicit_unsub_rc = libp2p_gossipsub_unsubscribe(gs, explicit_topic_name);
 		int explicit_unsub_ok = (explicit_unsub_rc == LIBP2P_ERR_OK);
 		print_result("gossipsub_explicit_unsubscribe", explicit_unsub_ok);
@@ -180,15 +180,15 @@ int gossipsub_service_run_explicit_peer_tests(gossipsub_service_test_env_t *env)
 	if (!(explicit_sub_ok && peering_add_ok))
 	{
 		if (peering_add_ok)
-			(void)libp2p_gossipsub_peering_remove(gs, &explicit_peer);
+			(void)libp2p_gossipsub_peering_remove(gs, explicit_peer);
 		if (explicit_sub_ok)
 			(void)libp2p_gossipsub_unsubscribe(gs, explicit_topic_name);
 	}
 
 	if (explicit_peer_ok)
-		peer_id_free(&explicit_peer);
+		peer_id_free(explicit_peer);
 	if (mesh_peer_ok)
-		peer_id_free(&mesh_peer);
+		peer_id_free(mesh_peer);
 
 	return failures;
 }

--- a/tests/protocol/gossipsub/test_gossipsub_service_heartbeat.c
+++ b/tests/protocol/gossipsub/test_gossipsub_service_heartbeat.c
@@ -84,7 +84,7 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 		/* Regression: if a peer's stream write reports CLOSED/RESET/EOF, mark the peer as
 		 * disconnected so we don't keep enqueueing frames for it and leak memory / spam logs. */
 		const char *peer_str = "12D3KooWQvF8fCqVQk4CwPZ1NqK9h9kqg3jWm1e7j6r2pVw7JYxR";
-		peer_id_t peer = {0};
+		peer_id_t *peer = NULL;
 		int peer_ok = (peer_id_new_from_text(peer_str, &peer) == PEER_ID_OK);
 		print_result("gossipsub_stream_write_closed_peer_id", peer_ok);
 		if (!peer_ok)
@@ -94,8 +94,8 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 		if (peer_ok)
 		{
 			/* libp2p_stream_from_ops takes ownership of remote_peer */
-			peer_id_t *remote = (peer_id_t *)calloc(1, sizeof(*remote));
-			int remote_ok = (remote && peer_id_new_from_text(peer_str, remote) == PEER_ID_OK);
+			peer_id_t *remote = NULL;
+			int remote_ok = (peer_id_new_from_text(peer_str, &remote) == PEER_ID_OK);
 			print_result("gossipsub_stream_write_closed_remote_peer_alloc", remote_ok);
 			if (!remote_ok)
 				failures++;
@@ -129,7 +129,7 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 					gossipsub_on_stream_open(s, gs);
 
 					/* Ensure the peer is a propagation target for test/topic. */
-					err = libp2p_gossipsub__topic_mesh_add_peer(gs, "test/topic", &peer, 1);
+					err = libp2p_gossipsub__topic_mesh_add_peer(gs, "test/topic", peer, 1);
 					int mesh_add_ok = (err == LIBP2P_ERR_OK);
 					print_result("gossipsub_stream_write_closed_mesh_add", mesh_add_ok);
 					if (!mesh_add_ok)
@@ -137,7 +137,7 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 
 					/* Wait until any queued subscription frames are drained/cleared. */
 					size_t qlen = 0;
-					int idle_ok = gossipsub_wait_for_peer_idle(gs, &peer, 200, &qlen);
+					int idle_ok = gossipsub_wait_for_peer_idle(gs, peer, 200, &qlen);
 					print_result("gossipsub_stream_write_closed_idle_after_subscribe", idle_ok);
 					if (!idle_ok)
 						failures++;
@@ -168,7 +168,7 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 
 					/* Give the callback thread a moment, then verify no enqueue occurred. */
 					usleep(2000);
-					qlen = libp2p_gossipsub__peer_sendq_len(gs, &peer);
+					qlen = libp2p_gossipsub__peer_sendq_len(gs, peer);
 					int no_enqueue_ok = (qlen == 0);
 					print_result("gossipsub_stream_write_closed_no_enqueue", no_enqueue_ok);
 					if (!no_enqueue_ok)
@@ -188,22 +188,20 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 					free(ctx);
 				if (remote)
 				{
-					if (remote->bytes)
-						peer_id_free(remote);
-					free(remote);
+					peer_id_free(remote);
 				}
 			}
 		}
 
 		if (peer_ok)
-			peer_id_free(&peer);
+			peer_id_free(peer);
 	}
 
 	{
 		/* Regression: when a peer's current writing stream closes, drop queued
 		 * frames and mark disconnected so we don't keep retrying writes. */
 		const char *peer_str = "12D3KooWQ7W3zfBDSSY5YTbSsfXCMVvjJAnYXhYzu3PV6PvJkU8E";
-		peer_id_t peer = {0};
+		peer_id_t *peer = NULL;
 		int peer_ok = (peer_id_new_from_text(peer_str, &peer) == PEER_ID_OK);
 		print_result("gossipsub_stream_close_peer_id", peer_ok);
 		if (!peer_ok)
@@ -212,8 +210,8 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 		libp2p_stream_t *s = NULL;
 		if (peer_ok)
 		{
-			peer_id_t *remote = (peer_id_t *)calloc(1, sizeof(*remote));
-			int remote_ok = (remote && peer_id_new_from_text(peer_str, remote) == PEER_ID_OK);
+			peer_id_t *remote = NULL;
+			int remote_ok = (peer_id_new_from_text(peer_str, &remote) == PEER_ID_OK);
 			print_result("gossipsub_stream_close_remote_peer_alloc", remote_ok);
 			if (!remote_ok)
 				failures++;
@@ -244,14 +242,14 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 				if (stream_ok)
 				{
 					gossipsub_on_stream_open(s, gs);
-					err = libp2p_gossipsub__topic_mesh_add_peer(gs, "test/topic", &peer, 1);
+					err = libp2p_gossipsub__topic_mesh_add_peer(gs, "test/topic", peer, 1);
 					int mesh_add_ok = (err == LIBP2P_ERR_OK);
 					print_result("gossipsub_stream_close_mesh_add", mesh_add_ok);
 					if (!mesh_add_ok)
 						failures++;
 
 					/* Clear any subscription frames queued during open. */
-					(void)libp2p_gossipsub__peer_clear_sendq(gs, &peer);
+					(void)libp2p_gossipsub__peer_clear_sendq(gs, peer);
 					usleep(2000);
 
 					const uint8_t payload = 0x43;
@@ -276,9 +274,19 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 					if (!publish_ok)
 						failures++;
 
-					usleep(2000);
-					size_t qlen = libp2p_gossipsub__peer_sendq_len(gs, &peer);
-					int queued_ok = (qlen > 0);
+					/* Wait for publish propagation to enqueue the frame. */
+					size_t qlen = 0;
+					int queued_ok = 0;
+					for (int attempt = 0; attempt < 200; ++attempt)
+					{
+						qlen = libp2p_gossipsub__peer_sendq_len(gs, peer);
+						if (qlen > 0)
+						{
+							queued_ok = 1;
+							break;
+						}
+						usleep(1000);
+					}
 					print_result("gossipsub_stream_close_has_queue_before_close", queued_ok);
 					if (!queued_ok)
 						failures++;
@@ -287,7 +295,7 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 					gossipsub_on_stream_close(s, gs);
 
 					usleep(2000);
-					qlen = libp2p_gossipsub__peer_sendq_len(gs, &peer);
+					qlen = libp2p_gossipsub__peer_sendq_len(gs, peer);
 					int cleared_ok = (qlen == 0);
 					print_result("gossipsub_stream_close_queue_cleared", cleared_ok);
 					if (!cleared_ok)
@@ -301,7 +309,7 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 						failures++;
 
 					usleep(2000);
-					qlen = libp2p_gossipsub__peer_sendq_len(gs, &peer);
+					qlen = libp2p_gossipsub__peer_sendq_len(gs, peer);
 					int no_enqueue_ok = (qlen == 0);
 					print_result("gossipsub_stream_close_no_enqueue_after_close", no_enqueue_ok);
 					if (!no_enqueue_ok)
@@ -320,21 +328,19 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 					free(ctx);
 				if (remote)
 				{
-					if (remote->bytes)
-						peer_id_free(remote);
-					free(remote);
+					peer_id_free(remote);
 				}
 			}
 		}
 
 		if (peer_ok)
-			peer_id_free(&peer);
+			peer_id_free(peer);
 	}
 
 	{
 		const char *fanout_topic = "fanout/heartbeat";
 		const char *fanout_peer_str = "12D3KooWNsGu1ca6QiN29GTRxK6j22BYrhM1Y5AkwB68x5y61xwn";
-		peer_id_t fanout_peer = {0};
+		peer_id_t *fanout_peer = NULL;
 		int fanout_peer_ok = (peer_id_new_from_text(fanout_peer_str, &fanout_peer) == PEER_ID_OK);
 		print_result("gossipsub_heartbeat_fanout_peer_created", fanout_peer_ok);
 		if (!fanout_peer_ok)
@@ -342,7 +348,7 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 
 		if (fanout_peer_ok)
 		{
-			err = libp2p_gossipsub__topic_fanout_add_peer(gs, fanout_topic, &fanout_peer, -1, 1);
+			err = libp2p_gossipsub__topic_fanout_add_peer(gs, fanout_topic, fanout_peer, -1, 1);
 			int fanout_add_ok = (err == LIBP2P_ERR_OK);
 			print_result("gossipsub_heartbeat_fanout_add", fanout_add_ok);
 			if (!fanout_add_ok)
@@ -372,13 +378,13 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 		}
 
 		if (fanout_peer_ok)
-			peer_id_free(&fanout_peer);
+			peer_id_free(fanout_peer);
 	}
 
 	{
 		const char *mesh_topic = "mesh/heartbeat";
 		const char *mesh_peer_str = "12D3KooWHZjVdysJ8V5Y2Tyshzw31wY1M2fjTw83YVHC6rU1ttzv";
-		peer_id_t mesh_peer = {0};
+		peer_id_t *mesh_peer = NULL;
 		int mesh_peer_ok = (peer_id_new_from_text(mesh_peer_str, &mesh_peer) == PEER_ID_OK);
 		print_result("gossipsub_heartbeat_mesh_peer_created", mesh_peer_ok);
 		if (!mesh_peer_ok)
@@ -386,7 +392,7 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 
 		if (mesh_peer_ok)
 		{
-			err = libp2p_gossipsub__topic_mesh_add_peer(gs, mesh_topic, &mesh_peer, 1);
+			err = libp2p_gossipsub__topic_mesh_add_peer(gs, mesh_topic, mesh_peer, 1);
 			int mesh_add_ok = (err == LIBP2P_ERR_OK);
 			print_result("gossipsub_heartbeat_mesh_add", mesh_add_ok);
 			if (!mesh_add_ok)
@@ -394,7 +400,7 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 
 			if (mesh_add_ok)
 			{
-				err = libp2p_gossipsub__peer_set_connected(gs, &mesh_peer, 1);
+				err = libp2p_gossipsub__peer_set_connected(gs, mesh_peer, 1);
 				int mesh_connected_ok = (err == LIBP2P_ERR_OK);
 				print_result("gossipsub_heartbeat_mesh_connected_initial", mesh_connected_ok);
 				if (!mesh_connected_ok)
@@ -406,7 +412,7 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 				if (!mesh_sz_ok)
 					failures++;
 
-				err = libp2p_gossipsub__peer_set_connected(gs, &mesh_peer, 0);
+				err = libp2p_gossipsub__peer_set_connected(gs, mesh_peer, 0);
 				int mesh_disconnected_ok = (err == LIBP2P_ERR_OK);
 				print_result("gossipsub_heartbeat_mesh_mark_disconnected", mesh_disconnected_ok);
 				if (!mesh_disconnected_ok)
@@ -427,7 +433,7 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 		}
 
 		if (mesh_peer_ok)
-			peer_id_free(&mesh_peer);
+			peer_id_free(mesh_peer);
 	}
 
 	{
@@ -446,7 +452,7 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 					   "12D3KooWFjecZx2YM5mAZ1bn46vCeWkQS9KpVwhM2r36EJt2vqCr",
 					   "12D3KooWDH8u1o1YiA1HXSwSReT7PwtZDs7JhdYKbnvSYnUrWhp2"};
 		const size_t peer_count = sizeof(peer_strs) / sizeof(peer_strs[0]);
-		peer_id_t peers[sizeof(peer_strs) / sizeof(peer_strs[0])];
+		peer_id_t *peers[sizeof(peer_strs) / sizeof(peer_strs[0])];
 		memset(peers, 0, sizeof(peers));
 		int peers_created = 1;
 		for (size_t i = 0; i < peer_count; ++i)
@@ -476,7 +482,7 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 				else
 				{
 					libp2p_err_t inj_rc =
-						libp2p_gossipsub__inject_frame(gs, &peers[i], frame, frame_len);
+						libp2p_gossipsub__inject_frame(gs, peers[i], frame, frame_len);
 					if (inj_rc != LIBP2P_ERR_OK)
 						subscriptions_ok = 0;
 				}
@@ -484,7 +490,8 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 					free(frame);
 				if (!subscriptions_ok)
 					break;
-				(void)libp2p_gossipsub__peer_clear_sendq(gs, &peers[i]);
+				(void)libp2p_gossipsub__peer_clear_sendq(gs, peers[i]);
+				(void)libp2p_gossipsub__peer_set_connected(gs, peers[i], 1);
 			}
 			print_result("gossipsub_heartbeat_mesh_fill_subscriptions", subscriptions_ok);
 			if (!subscriptions_ok)
@@ -506,7 +513,7 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 
 				for (size_t i = 0; i < peer_count; ++i)
 				{
-					int contains = libp2p_gossipsub__topic_mesh_contains(gs, topic_name, &peers[i],
+					int contains = libp2p_gossipsub__topic_mesh_contains(gs, topic_name, peers[i],
 											     NULL, NULL);
 					print_result("gossipsub_heartbeat_mesh_fill_contains", contains);
 					if (!contains)
@@ -515,7 +522,7 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 					uint8_t *frame = NULL;
 					size_t frame_len = 0;
 					libp2p_err_t pop_rc =
-						libp2p_gossipsub__peer_pop_sendq(gs, &peers[i], &frame, &frame_len);
+						libp2p_gossipsub__peer_pop_sendq(gs, peers[i], &frame, &frame_len);
 					int graft_seen = 0;
 					if (pop_rc == LIBP2P_ERR_OK && frame && frame_len)
 					{
@@ -567,11 +574,11 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 
 		for (size_t i = 0; i < peer_count; ++i)
 		{
-			if (peers[i].bytes)
+			if (peers[i])
 			{
-				(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, &peers[i]);
-				(void)libp2p_gossipsub__peer_clear_sendq(gs, &peers[i]);
-				peer_id_free(&peers[i]);
+				(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, peers[i]);
+				(void)libp2p_gossipsub__peer_clear_sendq(gs, peers[i]);
+				peer_id_free(peers[i]);
 			}
 		}
 		libp2p_gossipsub_unsubscribe(gs, topic_name);
@@ -597,7 +604,7 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 					   "12D3KooWLMEFQv1YCGxHNNVPiNzYfs2E31L6m1g9A3PXCAYpZrVQ",
 					   "12D3KooWJMCZpZGsGWpRieyU7gnaNmJKbnHiKK4xqSSdoRRt9P5r"};
 		const size_t peer_count = sizeof(peer_strs) / sizeof(peer_strs[0]);
-		peer_id_t peers[sizeof(peer_strs) / sizeof(peer_strs[0])];
+		peer_id_t *peers[sizeof(peer_strs) / sizeof(peer_strs[0])];
 		memset(peers, 0, sizeof(peers));
 		int peers_created = 1;
 		for (size_t i = 0; i < peer_count; ++i)
@@ -627,7 +634,7 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 				else
 				{
 					libp2p_err_t inj_rc =
-						libp2p_gossipsub__inject_frame(gs, &peers[i], frame, frame_len);
+						libp2p_gossipsub__inject_frame(gs, peers[i], frame, frame_len);
 					if (inj_rc != LIBP2P_ERR_OK)
 						setup_ok = 0;
 				}
@@ -636,20 +643,20 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 				if (!setup_ok)
 					break;
 
-				libp2p_err_t conn_rc = libp2p_gossipsub__peer_set_connected(gs, &peers[i], 1);
+				libp2p_err_t conn_rc = libp2p_gossipsub__peer_set_connected(gs, peers[i], 1);
 				if (conn_rc != LIBP2P_ERR_OK)
 				{
 					setup_ok = 0;
 					break;
 				}
 				libp2p_err_t mesh_rc =
-					libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, &peers[i], (int)(i % 2));
+					libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, peers[i], (int)(i % 2));
 				if (mesh_rc != LIBP2P_ERR_OK)
 				{
 					setup_ok = 0;
 					break;
 				}
-				(void)libp2p_gossipsub__peer_clear_sendq(gs, &peers[i]);
+				(void)libp2p_gossipsub__peer_clear_sendq(gs, peers[i]);
 			}
 			print_result("gossipsub_heartbeat_prune_setup", setup_ok);
 			if (!setup_ok)
@@ -678,7 +685,7 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 				size_t pruned_count = 0;
 				for (size_t i = 0; i < peer_count; ++i)
 				{
-					int in_mesh = libp2p_gossipsub__topic_mesh_contains(gs, topic_name, &peers[i],
+					int in_mesh = libp2p_gossipsub__topic_mesh_contains(gs, topic_name, peers[i],
 											    NULL, NULL);
 					if (!in_mesh)
 					{
@@ -689,7 +696,7 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 							uint8_t *frame = NULL;
 							size_t frame_len = 0;
 							libp2p_err_t pop_rc = libp2p_gossipsub__peer_pop_sendq(
-								gs, &peers[i], &frame, &frame_len);
+								gs, peers[i], &frame, &frame_len);
 							if (pop_rc != LIBP2P_ERR_OK || !frame || frame_len == 0)
 							{
 								if (frame)
@@ -754,12 +761,12 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 
 		for (size_t i = 0; i < peer_count; ++i)
 		{
-			if (peers[i].bytes)
+			if (peers[i])
 			{
-				(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, &peers[i]);
-				(void)libp2p_gossipsub__peer_clear_sendq(gs, &peers[i]);
-				(void)libp2p_gossipsub__peer_set_connected(gs, &peers[i], 0);
-				peer_id_free(&peers[i]);
+				(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, peers[i]);
+				(void)libp2p_gossipsub__peer_clear_sendq(gs, peers[i]);
+				(void)libp2p_gossipsub__peer_set_connected(gs, peers[i], 0);
+				peer_id_free(peers[i]);
 			}
 		}
 		libp2p_gossipsub_unsubscribe(gs, topic_name);
@@ -787,7 +794,7 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 		const int outbound_flags[] = {1, 1, 0, 0, 0, 0, 0};
 		const double scores[] = {1.2, 0.1, 0.2, 1.0, 0.3, -0.2, 0.05};
 		const size_t peer_count = sizeof(peer_strs) / sizeof(peer_strs[0]);
-		peer_id_t peers[peer_count];
+		peer_id_t *peers[peer_count];
 		memset(peers, 0, sizeof(peers));
 		int peers_created = 1;
 		for (size_t i = 0; i < peer_count; ++i)
@@ -817,7 +824,7 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 				else
 				{
 					libp2p_err_t inj_rc =
-						libp2p_gossipsub__inject_frame(gs, &peers[i], frame, frame_len);
+						libp2p_gossipsub__inject_frame(gs, peers[i], frame, frame_len);
 					if (inj_rc != LIBP2P_ERR_OK)
 						setup_ok = 0;
 				}
@@ -826,17 +833,17 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 				if (!setup_ok)
 					break;
 
-				if (libp2p_gossipsub__peer_set_connected(gs, &peers[i], 1) != LIBP2P_ERR_OK)
+				if (libp2p_gossipsub__peer_set_connected(gs, peers[i], 1) != LIBP2P_ERR_OK)
 				{
 					setup_ok = 0;
 					break;
 				}
-				if (libp2p_gossipsub__peer_set_score(gs, &peers[i], scores[i]) != LIBP2P_ERR_OK)
+				if (libp2p_gossipsub__peer_set_score(gs, peers[i], scores[i]) != LIBP2P_ERR_OK)
 				{
 					setup_ok = 0;
 					break;
 				}
-				if (libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, &peers[i],
+				if (libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, peers[i],
 									  outbound_flags[i]) != LIBP2P_ERR_OK)
 				{
 					setup_ok = 0;
@@ -873,7 +880,7 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 				for (size_t i = 0; i < peer_count; ++i)
 				{
 					int outbound = 0;
-					int in_mesh = libp2p_gossipsub__topic_mesh_contains(gs, topic_name, &peers[i],
+					int in_mesh = libp2p_gossipsub__topic_mesh_contains(gs, topic_name, peers[i],
 											    &outbound, NULL);
 					if (outbound_flags[i])
 					{
@@ -907,12 +914,12 @@ int gossipsub_service_run_heartbeat_and_gossip_tests(gossipsub_service_test_env_
 
 		for (size_t i = 0; i < peer_count; ++i)
 		{
-			if (peers[i].bytes)
+			if (peers[i])
 			{
-				(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, &peers[i]);
-				(void)libp2p_gossipsub__peer_clear_sendq(gs, &peers[i]);
-				(void)libp2p_gossipsub__peer_set_connected(gs, &peers[i], 0);
-				peer_id_free(&peers[i]);
+				(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, peers[i]);
+				(void)libp2p_gossipsub__peer_clear_sendq(gs, peers[i]);
+				(void)libp2p_gossipsub__peer_set_connected(gs, peers[i], 0);
+				peer_id_free(peers[i]);
 			}
 		}
 		libp2p_gossipsub_unsubscribe(gs, topic_name);

--- a/tests/protocol/gossipsub/test_gossipsub_service_px.c
+++ b/tests/protocol/gossipsub/test_gossipsub_service_px.c
@@ -34,7 +34,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 		const double scores[] = {1.2, 0.9, 0.8, 0.7, 0.6, 0.55, 0.1};
 		const size_t peer_count = sizeof(peer_strs) / sizeof(peer_strs[0]);
 		const size_t target_index = peer_count - 1;
-		peer_id_t peers[peer_count];
+		peer_id_t *peers[peer_count];
 		memset(peers, 0, sizeof(peers));
 		int peers_created = 1;
 		for (size_t i = 0; i < peer_count; ++i)
@@ -64,7 +64,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				else
 				{
 					libp2p_err_t inj_rc =
-						libp2p_gossipsub__inject_frame(gs, &peers[i], frame, frame_len);
+						libp2p_gossipsub__inject_frame(gs, peers[i], frame, frame_len);
 					if (inj_rc != LIBP2P_ERR_OK)
 						setup_ok = 0;
 				}
@@ -73,17 +73,17 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				if (!setup_ok)
 					break;
 
-				if (libp2p_gossipsub__peer_set_connected(gs, &peers[i], 1) != LIBP2P_ERR_OK)
+				if (libp2p_gossipsub__peer_set_connected(gs, peers[i], 1) != LIBP2P_ERR_OK)
 				{
 					setup_ok = 0;
 					break;
 				}
-				if (libp2p_gossipsub__peer_set_score(gs, &peers[i], scores[i]) != LIBP2P_ERR_OK)
+				if (libp2p_gossipsub__peer_set_score(gs, peers[i], scores[i]) != LIBP2P_ERR_OK)
 				{
 					setup_ok = 0;
 					break;
 				}
-				if (libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, &peers[i],
+				if (libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, peers[i],
 									  outbound_flags[i]) != LIBP2P_ERR_OK)
 				{
 					setup_ok = 0;
@@ -104,7 +104,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 				int target_outbound = 0;
 				int target_in_mesh = libp2p_gossipsub__topic_mesh_contains(
-					gs, topic_name, &peers[target_index], &target_outbound, NULL);
+					gs, topic_name, peers[target_index], &target_outbound, NULL);
 				(void)target_outbound;
 				int target_pruned = !target_in_mesh;
 				print_result("gossipsub_px_threshold_low_pruned", target_pruned);
@@ -120,7 +120,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 						uint8_t *frame = NULL;
 						size_t frame_len = 0;
 						libp2p_err_t pop_rc = libp2p_gossipsub__peer_pop_sendq(
-							gs, &peers[target_index], &frame, &frame_len);
+							gs, peers[target_index], &frame, &frame_len);
 						if (pop_rc != LIBP2P_ERR_OK || !frame || frame_len == 0)
 						{
 							if (frame)
@@ -148,12 +148,12 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 		for (size_t i = 0; i < peer_count; ++i)
 		{
-			if (peers[i].bytes)
+			if (peers[i])
 			{
-				(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, &peers[i]);
-				(void)libp2p_gossipsub__peer_clear_sendq(gs, &peers[i]);
-				(void)libp2p_gossipsub__peer_set_connected(gs, &peers[i], 0);
-				peer_id_free(&peers[i]);
+				(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, peers[i]);
+				(void)libp2p_gossipsub__peer_clear_sendq(gs, peers[i]);
+				(void)libp2p_gossipsub__peer_set_connected(gs, peers[i], 0);
+				peer_id_free(peers[i]);
 			}
 		}
 		libp2p_gossipsub_unsubscribe(gs, topic_name);
@@ -182,7 +182,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 		const double scores[] = {1.5, 1.3, 1.1, 0.9, 0.8, 0.75, 0.7};
 		const size_t peer_count = sizeof(peer_strs) / sizeof(peer_strs[0]);
 		const size_t target_index = peer_count - 1;
-		peer_id_t peers[peer_count];
+		peer_id_t *peers[peer_count];
 		memset(peers, 0, sizeof(peers));
 		int peers_created = 1;
 		for (size_t i = 0; i < peer_count; ++i)
@@ -212,7 +212,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				else
 				{
 					libp2p_err_t inj_rc =
-						libp2p_gossipsub__inject_frame(gs, &peers[i], frame, frame_len);
+						libp2p_gossipsub__inject_frame(gs, peers[i], frame, frame_len);
 					if (inj_rc != LIBP2P_ERR_OK)
 						setup_ok = 0;
 				}
@@ -221,17 +221,17 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				if (!setup_ok)
 					break;
 
-				if (libp2p_gossipsub__peer_set_connected(gs, &peers[i], 1) != LIBP2P_ERR_OK)
+				if (libp2p_gossipsub__peer_set_connected(gs, peers[i], 1) != LIBP2P_ERR_OK)
 				{
 					setup_ok = 0;
 					break;
 				}
-				if (libp2p_gossipsub__peer_set_score(gs, &peers[i], scores[i]) != LIBP2P_ERR_OK)
+				if (libp2p_gossipsub__peer_set_score(gs, peers[i], scores[i]) != LIBP2P_ERR_OK)
 				{
 					setup_ok = 0;
 					break;
 				}
-				if (libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, &peers[i],
+				if (libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, peers[i],
 									  outbound_flags[i]) != LIBP2P_ERR_OK)
 				{
 					setup_ok = 0;
@@ -252,7 +252,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 				int target_outbound = 0;
 				int target_in_mesh = libp2p_gossipsub__topic_mesh_contains(
-					gs, topic_name, &peers[target_index], &target_outbound, NULL);
+					gs, topic_name, peers[target_index], &target_outbound, NULL);
 				(void)target_outbound;
 				int target_pruned = !target_in_mesh;
 				print_result("gossipsub_px_threshold_high_pruned", target_pruned);
@@ -268,7 +268,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 						uint8_t *frame = NULL;
 						size_t frame_len = 0;
 						libp2p_err_t pop_rc = libp2p_gossipsub__peer_pop_sendq(
-							gs, &peers[target_index], &frame, &frame_len);
+							gs, peers[target_index], &frame, &frame_len);
 						if (pop_rc != LIBP2P_ERR_OK || !frame || frame_len == 0)
 						{
 							if (frame)
@@ -296,12 +296,12 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 		for (size_t i = 0; i < peer_count; ++i)
 		{
-			if (peers[i].bytes)
+			if (peers[i])
 			{
-				(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, &peers[i]);
-				(void)libp2p_gossipsub__peer_clear_sendq(gs, &peers[i]);
-				(void)libp2p_gossipsub__peer_set_connected(gs, &peers[i], 0);
-				peer_id_free(&peers[i]);
+				(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, peers[i]);
+				(void)libp2p_gossipsub__peer_clear_sendq(gs, peers[i]);
+				(void)libp2p_gossipsub__peer_set_connected(gs, peers[i], 0);
+				peer_id_free(peers[i]);
 			}
 		}
 		libp2p_gossipsub_unsubscribe(gs, topic_name);
@@ -320,13 +320,13 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			failures++;
 
 		const char *sender_str = "12D3KooWQah6XuKrg7vitgGdzDMn9jVQuk9AGK2Gkz9g9miHKXDN";
-		peer_id_t sender_peer = {0};
+		peer_id_t *sender_peer = NULL;
 		int sender_ok = subscribe_ok && setup_gossip_peer(gs, topic_name, sender_str, &sender_peer);
 		print_result("gossipsub_px_ingest_setup_sender", sender_ok);
 		if (!sender_ok)
 			failures++;
 
-		peer_id_t px_peer = {0};
+		peer_id_t *px_peer = NULL;
 		ed25519_secret_key px_secret;
 		memcpy(px_secret, kTestPxSecretKey, sizeof(px_secret));
 		ed25519_public_key px_public;
@@ -354,8 +354,8 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 		if (sender_ok)
 		{
-			libp2p_gossipsub__peer_set_score(gs, &sender_peer, cfg.accept_px_threshold + 1.0);
-			(void)libp2p_gossipsub__peer_clear_sendq(gs, &sender_peer);
+			libp2p_gossipsub__peer_set_score(gs, sender_peer, cfg.accept_px_threshold + 1.0);
+			(void)libp2p_gossipsub__peer_clear_sendq(gs, sender_peer);
 		}
 
 		if (sender_ok && px_peer_ok && addr_ok)
@@ -364,7 +364,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			uint8_t *record_buf = NULL;
 			size_t record_len = 0;
 			libp2p_err_t rec_rc =
-				encode_signed_peer_record(&px_peer, addr_list, 1, kTestPxSecretKey,
+				encode_signed_peer_record(px_peer, addr_list, 1, kTestPxSecretKey,
 							  sizeof(kTestPxSecretKey), &record_buf, &record_len);
 			int record_ok = (rec_rc == LIBP2P_ERR_OK && record_buf && record_len > 0);
 			print_result("gossipsub_px_ingest_encode_record", record_ok);
@@ -375,7 +375,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			{
 				uint8_t *prune_frame = NULL;
 				size_t prune_len = 0;
-				libp2p_err_t prune_rc = encode_prune_px_rpc(topic_name, &px_peer, record_buf,
+				libp2p_err_t prune_rc = encode_prune_px_rpc(topic_name, px_peer, record_buf,
 									    record_len, &prune_frame, &prune_len);
 				int prune_ok = (prune_rc == LIBP2P_ERR_OK && prune_frame && prune_len > 0);
 				print_result("gossipsub_px_ingest_encode_prune", prune_ok);
@@ -384,7 +384,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 				if (prune_ok)
 				{
-					libp2p_err_t inj_rc = libp2p_gossipsub__inject_frame(gs, &sender_peer,
+					libp2p_err_t inj_rc = libp2p_gossipsub__inject_frame(gs, sender_peer,
 											     prune_frame, prune_len);
 					int inject_ok = (inj_rc == LIBP2P_ERR_OK);
 					print_result("gossipsub_px_ingest_inject_prune", inject_ok);
@@ -395,7 +395,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 					{
 						const multiaddr_t **stored = NULL;
 						size_t stored_len = 0;
-						int ps_rc = libp2p_peerstore_get_addrs(host->peerstore, &px_peer,
+						int ps_rc = libp2p_peerstore_get_addrs(host->peerstore, px_peer,
 										       &stored, &stored_len);
 						int peerstore_ok = (ps_rc == 0 && stored && stored_len > 0);
 						print_result("gossipsub_px_ingest_peerstore_lookup", peerstore_ok);
@@ -444,13 +444,13 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 		if (px_addr)
 			multiaddr_free(px_addr);
-		if (px_peer.bytes)
-			peer_id_free(&px_peer);
-		if (sender_peer.bytes)
+		if (px_peer)
+			peer_id_free(px_peer);
+		if (sender_peer)
 		{
 			if (sender_ok)
-				(void)libp2p_gossipsub__peer_set_connected(gs, &sender_peer, 0);
-			peer_id_free(&sender_peer);
+				(void)libp2p_gossipsub__peer_set_connected(gs, sender_peer, 0);
+			peer_id_free(sender_peer);
 		}
 		if (subscribe_ok)
 			libp2p_gossipsub_unsubscribe(gs, topic_name);
@@ -473,7 +473,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 						"12D3KooWDbSkFwsij4BjjHfZxQqJ1zuvBABFqQ5uwSX6ZiUvUv9d",
 						"12D3KooWN9oSkqZSS7Y7gsnAmfmNgmcByKYEzGyv1mCXN8vQiyTe"};
 		const size_t mesh_count = sizeof(mesh_peer_strs) / sizeof(mesh_peer_strs[0]);
-		peer_id_t mesh_peers[sizeof(mesh_peer_strs) / sizeof(mesh_peer_strs[0])];
+		peer_id_t *mesh_peers[sizeof(mesh_peer_strs) / sizeof(mesh_peer_strs[0])];
 		memset(mesh_peers, 0, sizeof(mesh_peers));
 		int mesh_peers_ok = 1;
 		for (size_t i = 0; i < mesh_count; ++i)
@@ -489,7 +489,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			failures++;
 
 		const char *gossip_peer_str = "12D3KooWNsGu1ca6QiN29GTRxK6j22BYrhM1Y5AkwB68x5y61xwn";
-		peer_id_t gossip_peer = {0};
+		peer_id_t *gossip_peer = NULL;
 		int gossip_peer_ok = (peer_id_new_from_text(gossip_peer_str, &gossip_peer) == PEER_ID_OK);
 		print_result("gossipsub_heartbeat_gossip_peer", gossip_peer_ok);
 		if (!gossip_peer_ok)
@@ -510,7 +510,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				else
 				{
 					libp2p_err_t inj_rc =
-						libp2p_gossipsub__inject_frame(gs, &mesh_peers[i], frame, frame_len);
+						libp2p_gossipsub__inject_frame(gs, mesh_peers[i], frame, frame_len);
 					if (inj_rc != LIBP2P_ERR_OK)
 						setup_ok = 0;
 				}
@@ -519,7 +519,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				if (!setup_ok)
 					break;
 
-				libp2p_err_t conn_rc = libp2p_gossipsub__peer_set_connected(gs, &mesh_peers[i], 1);
+				libp2p_err_t conn_rc = libp2p_gossipsub__peer_set_connected(gs, mesh_peers[i], 1);
 				if (conn_rc != LIBP2P_ERR_OK)
 				{
 					setup_ok = 0;
@@ -527,13 +527,13 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				}
 
 				libp2p_err_t mesh_rc =
-					libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, &mesh_peers[i], 1);
+					libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, mesh_peers[i], 1);
 				if (mesh_rc != LIBP2P_ERR_OK)
 				{
 					setup_ok = 0;
 					break;
 				}
-				(void)libp2p_gossipsub__peer_clear_sendq(gs, &mesh_peers[i]);
+				(void)libp2p_gossipsub__peer_clear_sendq(gs, mesh_peers[i]);
 			}
 
 			if (setup_ok)
@@ -548,7 +548,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				else
 				{
 					libp2p_err_t inj_rc =
-						libp2p_gossipsub__inject_frame(gs, &gossip_peer, frame, frame_len);
+						libp2p_gossipsub__inject_frame(gs, gossip_peer, frame, frame_len);
 					if (inj_rc != LIBP2P_ERR_OK)
 						setup_ok = 0;
 				}
@@ -557,11 +557,11 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				if (setup_ok)
 				{
 					libp2p_err_t conn_rc =
-						libp2p_gossipsub__peer_set_connected(gs, &gossip_peer, 1);
+						libp2p_gossipsub__peer_set_connected(gs, gossip_peer, 1);
 					if (conn_rc != LIBP2P_ERR_OK)
 						setup_ok = 0;
 				}
-				(void)libp2p_gossipsub__peer_clear_sendq(gs, &gossip_peer);
+				(void)libp2p_gossipsub__peer_clear_sendq(gs, gossip_peer);
 			}
 
 			print_result("gossipsub_heartbeat_gossip_setup", setup_ok);
@@ -601,7 +601,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 						for (size_t i = 0; i < mesh_count; ++i)
 						{
 							size_t qlen =
-								libp2p_gossipsub__peer_sendq_len(gs, &mesh_peers[i]);
+								libp2p_gossipsub__peer_sendq_len(gs, mesh_peers[i]);
 							if (qlen == 0)
 							{
 								mesh_queues_ready = 0;
@@ -616,8 +616,8 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 						failures++;
 
 					for (size_t i = 0; i < mesh_count; ++i)
-						(void)libp2p_gossipsub__peer_clear_sendq(gs, &mesh_peers[i]);
-					(void)libp2p_gossipsub__peer_clear_sendq(gs, &gossip_peer);
+						(void)libp2p_gossipsub__peer_clear_sendq(gs, mesh_peers[i]);
+					(void)libp2p_gossipsub__peer_clear_sendq(gs, gossip_peer);
 
 					libp2p_err_t hb_rc = libp2p_gossipsub__heartbeat(gs);
 					int hb_ok = (hb_rc == LIBP2P_ERR_OK);
@@ -626,7 +626,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 						failures++;
 
 					int gossip_in_mesh = libp2p_gossipsub__topic_mesh_contains(
-						gs, topic_name, &gossip_peer, NULL, NULL);
+						gs, topic_name, gossip_peer, NULL, NULL);
 					int gossip_outside_mesh_ok = !gossip_in_mesh;
 					print_result("gossipsub_heartbeat_gossip_peer_mesh", gossip_outside_mesh_ok);
 					if (!gossip_outside_mesh_ok)
@@ -635,7 +635,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 					uint8_t *frame = NULL;
 					size_t frame_len = 0;
 					libp2p_err_t pop_rc =
-						libp2p_gossipsub__peer_pop_sendq(gs, &gossip_peer, &frame, &frame_len);
+						libp2p_gossipsub__peer_pop_sendq(gs, gossip_peer, &frame, &frame_len);
 					int ihave_seen = 0;
 					if (pop_rc == LIBP2P_ERR_OK && frame && frame_len)
 					{
@@ -689,17 +689,17 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 		for (size_t i = 0; i < mesh_count; ++i)
 		{
-			if (mesh_peers[i].bytes)
+			if (mesh_peers[i])
 			{
-				(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, &mesh_peers[i]);
-				(void)libp2p_gossipsub__peer_clear_sendq(gs, &mesh_peers[i]);
-				peer_id_free(&mesh_peers[i]);
+				(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, mesh_peers[i]);
+				(void)libp2p_gossipsub__peer_clear_sendq(gs, mesh_peers[i]);
+				peer_id_free(mesh_peers[i]);
 			}
 		}
-		if (gossip_peer.bytes)
+		if (gossip_peer)
 		{
-			(void)libp2p_gossipsub__peer_clear_sendq(gs, &gossip_peer);
-			peer_id_free(&gossip_peer);
+			(void)libp2p_gossipsub__peer_clear_sendq(gs, gossip_peer);
+			peer_id_free(gossip_peer);
 		}
 		libp2p_gossipsub_unsubscribe(gs, topic_name);
 	}
@@ -799,7 +799,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 		const size_t lazy_count = LAZY_COUNT;
 		const size_t extra_count = EXTRA_COUNT;
 		const size_t total_count = TOTAL_COUNT;
-		peer_id_t gossip_peers[TOTAL_COUNT];
+		peer_id_t *gossip_peers[TOTAL_COUNT];
 		memset(gossip_peers, 0, sizeof(gossip_peers));
 
 		int gossip_setup_ok = 1;
@@ -836,13 +836,13 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				       gossipsub_debug_last_eligible, actual_expected_lazy);
 				for (size_t i = 0; i < lazy_count; ++i)
 				{
-					size_t qlen = libp2p_gossipsub__peer_sendq_len(local_gs, &gossip_peers[i]);
+					size_t qlen = libp2p_gossipsub__peer_sendq_len(local_gs, gossip_peers[i]);
 					if (qlen)
 					{
 						printf("DETAIL: lazy_peer[%zu] queue=%zu\n", i, qlen);
 						uint8_t *frame_buf = NULL;
 						size_t frame_len = 0;
-						if (libp2p_gossipsub__peer_pop_sendq(local_gs, &gossip_peers[i],
+						if (libp2p_gossipsub__peer_pop_sendq(local_gs, gossip_peers[i],
 										     &frame_buf,
 										     &frame_len) == LIBP2P_ERR_OK)
 						{
@@ -866,7 +866,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			}
 			print_result("gossipsub_gossip_factor_lazy_limit", lazy_scenario_ok);
 			for (size_t i = 0; i < lazy_count; ++i)
-				(void)libp2p_gossipsub__peer_clear_sendq(local_gs, &gossip_peers[i]);
+				(void)libp2p_gossipsub__peer_clear_sendq(local_gs, gossip_peers[i]);
 		}
 
 		int extra_setup_ok = 0;
@@ -910,7 +910,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				       factor_limit, gossipsub_debug_last_eligible, actual_expected_factor);
 				for (size_t i = 0; i < total_count; ++i)
 				{
-					size_t qlen = libp2p_gossipsub__peer_sendq_len(local_gs, &gossip_peers[i]);
+					size_t qlen = libp2p_gossipsub__peer_sendq_len(local_gs, gossip_peers[i]);
 					if (qlen)
 						printf("DETAIL: percent_peer[%zu] queue=%zu\n", i, qlen);
 				}
@@ -918,15 +918,15 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			}
 			print_result("gossipsub_gossip_factor_percent_limit", factor_scenario_ok);
 			for (size_t i = 0; i < total_count; ++i)
-				(void)libp2p_gossipsub__peer_clear_sendq(local_gs, &gossip_peers[i]);
+				(void)libp2p_gossipsub__peer_clear_sendq(local_gs, gossip_peers[i]);
 		}
 
 		for (size_t i = 0; i < total_count; ++i)
 		{
-			if (gossip_peers[i].bytes)
+			if (gossip_peers[i])
 			{
-				(void)libp2p_gossipsub__peer_clear_sendq(local_gs, &gossip_peers[i]);
-				peer_id_free(&gossip_peers[i]);
+				(void)libp2p_gossipsub__peer_clear_sendq(local_gs, gossip_peers[i]);
+				peer_id_free(gossip_peers[i]);
 			}
 		}
 
@@ -950,7 +950,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			failures++;
 
 		const char *mesh_peer_str = "12D3KooWQX1pP6uPQ7RZicMv6z4dGYBHc9B7iKLB9gowgCJFzQEw";
-		peer_id_t mesh_peer = {0};
+		peer_id_t *mesh_peer = NULL;
 		int mesh_peer_ok = (peer_id_new_from_text(mesh_peer_str, &mesh_peer) == PEER_ID_OK);
 		print_result("gossipsub_propagation_peer_id_created", mesh_peer_ok);
 		if (!mesh_peer_ok)
@@ -958,7 +958,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 		if (subscribe_ok && mesh_peer_ok)
 		{
-			err = libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, &mesh_peer, 1);
+			err = libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, mesh_peer, 1);
 			int mesh_add_ok = (err == LIBP2P_ERR_OK);
 			print_result("gossipsub_propagation_mesh_add_peer", mesh_add_ok);
 			if (!mesh_add_ok)
@@ -966,7 +966,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 			if (mesh_add_ok)
 			{
-				err = libp2p_gossipsub__peer_set_connected(gs, &mesh_peer, 1);
+				err = libp2p_gossipsub__peer_set_connected(gs, mesh_peer, 1);
 				int connected_ok = (err == LIBP2P_ERR_OK);
 				print_result("gossipsub_propagation_peer_connected", connected_ok);
 				if (!connected_ok)
@@ -974,7 +974,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 				if (connected_ok)
 				{
-					(void)libp2p_gossipsub__peer_clear_sendq(gs, &mesh_peer);
+					(void)libp2p_gossipsub__peer_clear_sendq(gs, mesh_peer);
 
 					const uint8_t payload[] = {0xAA, 0xBB, 0xCC, 0xDD};
 					libp2p_gossipsub_message_t pub_msg = {
@@ -996,7 +996,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 					if (publish_ok)
 					{
 						usleep(10000);
-						size_t qlen_first = libp2p_gossipsub__peer_sendq_len(gs, &mesh_peer);
+						size_t qlen_first = libp2p_gossipsub__peer_sendq_len(gs, mesh_peer);
 						int qlen_first_ok = (qlen_first >= 1);
 						print_result("gossipsub_propagation_queue_after_first", qlen_first_ok);
 						if (!qlen_first_ok)
@@ -1004,7 +1004,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 						if (qlen_first_ok)
 						{
-							(void)libp2p_gossipsub__peer_clear_sendq(gs, &mesh_peer);
+							(void)libp2p_gossipsub__peer_clear_sendq(gs, mesh_peer);
 
 							err = libp2p_gossipsub_publish(gs, &pub_msg);
 							int publish_again_ok = (err == LIBP2P_ERR_OK);
@@ -1017,7 +1017,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 							{
 								usleep(10000);
 								size_t qlen_second = libp2p_gossipsub__peer_sendq_len(
-									gs, &mesh_peer);
+									gs, mesh_peer);
 								int qlen_second_ok = (qlen_second >= 1);
 								print_result("gossipsub_propagation_queue_after_second",
 									     qlen_second_ok);
@@ -1031,7 +1031,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 		}
 
 		if (mesh_peer_ok)
-			peer_id_free(&mesh_peer);
+			peer_id_free(mesh_peer);
 
 		if (subscribe_ok)
 		{
@@ -1057,8 +1057,8 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 		const char *source_peer_str = "12D3KooWNNK9n7fh5R7sFjstqA5H1vcs1PEqnbPGZL4sD7dJgxX8";
 		const char *target_peer_str = "12D3KooWNtgPTUpWHPUEK35GhPty1jih6e9SxWi81o2wDpyo5R3x";
-		peer_id_t source_peer = {0};
-		peer_id_t target_peer = {0};
+		peer_id_t *source_peer = NULL;
+		peer_id_t *target_peer = NULL;
 		int source_ok = (peer_id_new_from_text(source_peer_str, &source_peer) == PEER_ID_OK);
 		int target_ok = (peer_id_new_from_text(target_peer_str, &target_peer) == PEER_ID_OK);
 		print_result("gossipsub_inbound_source_peer_created", source_ok);
@@ -1070,7 +1070,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 		if (subscribe_ok && target_ok)
 		{
-			err = libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, &target_peer, 1);
+			err = libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, target_peer, 1);
 			int mesh_add_ok = (err == LIBP2P_ERR_OK);
 			print_result("gossipsub_inbound_mesh_add_target", mesh_add_ok);
 			if (!mesh_add_ok)
@@ -1078,7 +1078,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 			if (mesh_add_ok)
 			{
-				err = libp2p_gossipsub__peer_set_connected(gs, &target_peer, 1);
+				err = libp2p_gossipsub__peer_set_connected(gs, target_peer, 1);
 				int connected_ok = (err == LIBP2P_ERR_OK);
 				print_result("gossipsub_inbound_target_connected", connected_ok);
 				if (!connected_ok)
@@ -1088,7 +1088,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 		if (subscribe_ok && source_ok && target_ok)
 		{
-			(void)libp2p_gossipsub__peer_clear_sendq(gs, &target_peer);
+			(void)libp2p_gossipsub__peer_clear_sendq(gs, target_peer);
 
 			const uint8_t payload[] = {0x10, 0x20, 0x30, 0x40};
 			const uint8_t seqno[] = {0x01, 0x02, 0x03, 0x04};
@@ -1096,7 +1096,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				.topic = {.struct_size = sizeof(inbound_msg.topic), .topic = topic_name},
 				.data = payload,
 				.data_len = sizeof(payload),
-				.from = &source_peer,
+				.from = source_peer,
 				.seqno = seqno,
 				.seqno_len = sizeof(seqno),
 				.raw_message = NULL,
@@ -1113,7 +1113,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			if (encode_ok)
 			{
 				libp2p_err_t inj_rc =
-					libp2p_gossipsub__inject_frame(gs, &source_peer, frame, frame_len);
+					libp2p_gossipsub__inject_frame(gs, source_peer, frame, frame_len);
 				int inject_ok = (inj_rc == LIBP2P_ERR_OK);
 				print_result("gossipsub_inbound_inject_first", inject_ok);
 				if (!inject_ok)
@@ -1122,7 +1122,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				if (inject_ok)
 				{
 					usleep(10000);
-					size_t qlen_first = libp2p_gossipsub__peer_sendq_len(gs, &target_peer);
+					size_t qlen_first = libp2p_gossipsub__peer_sendq_len(gs, target_peer);
 					int qlen_first_ok = (qlen_first >= 1);
 					print_result("gossipsub_inbound_queue_after_first", qlen_first_ok);
 					if (!qlen_first_ok)
@@ -1130,7 +1130,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 					if (qlen_first_ok)
 					{
-						inj_rc = libp2p_gossipsub__inject_frame(gs, &source_peer, frame,
+						inj_rc = libp2p_gossipsub__inject_frame(gs, source_peer, frame,
 											frame_len);
 						int inject_second_ok = (inj_rc == LIBP2P_ERR_OK);
 						print_result("gossipsub_inbound_inject_second", inject_second_ok);
@@ -1141,7 +1141,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 						{
 							usleep(10000);
 							size_t qlen_second =
-								libp2p_gossipsub__peer_sendq_len(gs, &target_peer);
+								libp2p_gossipsub__peer_sendq_len(gs, target_peer);
 							int dedup_ok = (qlen_second == qlen_first);
 							print_result("gossipsub_inbound_dedup", dedup_ok);
 							if (!dedup_ok)
@@ -1155,9 +1155,9 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 		}
 
 		if (target_ok)
-			peer_id_free(&target_peer);
+			peer_id_free(target_peer);
 		if (source_ok)
-			peer_id_free(&source_peer);
+			peer_id_free(source_peer);
 
 		if (subscribe_ok)
 		{
@@ -1185,8 +1185,8 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 		const char *source_peer_str = "12D3KooWRGFmLWY4kCMgWyBTsmVEx9BwM8yHceSX8tRCJatG9A6L";
 		const char *target_peer_str = "12D3KooWE9q4DXG4bqBNY3z3y7mEys6DKUkFyjtL1hwy6v3HXyFG";
-		peer_id_t source_peer = {0};
-		peer_id_t target_peer = {0};
+		peer_id_t *source_peer = NULL;
+		peer_id_t *target_peer = NULL;
 		int source_ok = (peer_id_new_from_text(source_peer_str, &source_peer) == PEER_ID_OK);
 		int target_ok = (peer_id_new_from_text(target_peer_str, &target_peer) == PEER_ID_OK);
 		print_result("gossipsub_custom_id_source_peer", source_ok);
@@ -1198,7 +1198,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 		if (subscribe_ok && target_ok)
 		{
-			err = libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, &target_peer, 1);
+			err = libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, target_peer, 1);
 			int mesh_add_ok = (err == LIBP2P_ERR_OK);
 			print_result("gossipsub_custom_id_mesh_add", mesh_add_ok);
 			if (!mesh_add_ok)
@@ -1206,7 +1206,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 			if (mesh_add_ok)
 			{
-				err = libp2p_gossipsub__peer_set_connected(gs, &target_peer, 1);
+				err = libp2p_gossipsub__peer_set_connected(gs, target_peer, 1);
 				int connected_ok = (err == LIBP2P_ERR_OK);
 				print_result("gossipsub_custom_id_target_connected", connected_ok);
 				if (!connected_ok)
@@ -1216,7 +1216,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 		if (subscribe_ok && source_ok && target_ok)
 		{
-			(void)libp2p_gossipsub__peer_clear_sendq(gs, &target_peer);
+			(void)libp2p_gossipsub__peer_clear_sendq(gs, target_peer);
 
 			const uint8_t payload_first[] = {0x42, 0x01, 0x02};
 			const uint8_t payload_second[] = {0x42, 0x03, 0x04};
@@ -1227,7 +1227,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				.topic = {.struct_size = sizeof(first_msg.topic), .topic = topic_name},
 				.data = payload_first,
 				.data_len = sizeof(payload_first),
-				.from = &source_peer,
+				.from = source_peer,
 				.seqno = seqno_first,
 				.seqno_len = sizeof(seqno_first),
 				.raw_message = NULL,
@@ -1237,7 +1237,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				.topic = {.struct_size = sizeof(second_msg.topic), .topic = topic_name},
 				.data = payload_second,
 				.data_len = sizeof(payload_second),
-				.from = &source_peer,
+				.from = source_peer,
 				.seqno = seqno_second,
 				.seqno_len = sizeof(seqno_second),
 				.raw_message = NULL,
@@ -1264,7 +1264,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			if (encode_first_ok && encode_second_ok)
 			{
 				libp2p_err_t inj_rc =
-					libp2p_gossipsub__inject_frame(gs, &source_peer, frame_first, frame_first_len);
+					libp2p_gossipsub__inject_frame(gs, source_peer, frame_first, frame_first_len);
 				int inject_first_ok = (inj_rc == LIBP2P_ERR_OK);
 				print_result("gossipsub_custom_id_inject_first", inject_first_ok);
 				if (!inject_first_ok)
@@ -1273,7 +1273,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				if (inject_first_ok)
 				{
 					usleep(10000);
-					size_t qlen_first = libp2p_gossipsub__peer_sendq_len(gs, &target_peer);
+					size_t qlen_first = libp2p_gossipsub__peer_sendq_len(gs, target_peer);
 					int qlen_first_ok = (qlen_first >= 1);
 					print_result("gossipsub_custom_id_queue_after_first", qlen_first_ok);
 					if (!qlen_first_ok)
@@ -1281,7 +1281,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 					if (qlen_first_ok)
 					{
-						inj_rc = libp2p_gossipsub__inject_frame(gs, &source_peer, frame_second,
+						inj_rc = libp2p_gossipsub__inject_frame(gs, source_peer, frame_second,
 											frame_second_len);
 						int inject_second_ok = (inj_rc == LIBP2P_ERR_OK);
 						print_result("gossipsub_custom_id_inject_second", inject_second_ok);
@@ -1292,7 +1292,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 						{
 							usleep(10000);
 							size_t qlen_second =
-								libp2p_gossipsub__peer_sendq_len(gs, &target_peer);
+								libp2p_gossipsub__peer_sendq_len(gs, target_peer);
 							int dedup_ok = (qlen_second == qlen_first);
 							print_result("gossipsub_custom_id_dedup", dedup_ok);
 							if (!dedup_ok)
@@ -1306,13 +1306,13 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				free(frame_second);
 			if (frame_first)
 				free(frame_first);
-			(void)libp2p_gossipsub__peer_clear_sendq(gs, &target_peer);
+			(void)libp2p_gossipsub__peer_clear_sendq(gs, target_peer);
 		}
 
 		if (target_ok)
-			peer_id_free(&target_peer);
+			peer_id_free(target_peer);
 		if (source_ok)
-			peer_id_free(&source_peer);
+			peer_id_free(source_peer);
 
 		if (subscribe_ok)
 		{
@@ -1342,9 +1342,9 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 		const char *ihave_peer_str = "12D3KooWLMEFQv1YCGxHNNVPiNzYfs2E31L6m1g9A3PXCAYpZrVQ";
 		const char *request_peer_str = "12D3KooWExgVnyL9F9ktsHTTXV9cZ6rxWPPPwJ9V6u3yyFvEfYst";
 
-		peer_id_t source_peer = {0};
-		peer_id_t ihave_peer = {0};
-		peer_id_t request_peer = {0};
+		peer_id_t *source_peer = NULL;
+		peer_id_t *ihave_peer = NULL;
+		peer_id_t *request_peer = NULL;
 		int source_ok = (peer_id_new_from_text(source_peer_str, &source_peer) == PEER_ID_OK);
 		int ihave_ok = (peer_id_new_from_text(ihave_peer_str, &ihave_peer) == PEER_ID_OK);
 		int request_ok = (peer_id_new_from_text(request_peer_str, &request_peer) == PEER_ID_OK);
@@ -1359,13 +1359,17 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			failures++;
 
 		uint8_t seqno_bytes[4] = {0xDE, 0xAD, 0xBE, 0xEF};
-		size_t message_id_len = source_peer.size + sizeof(seqno_bytes);
+		const uint8_t *source_mh = NULL;
+		size_t source_mh_len = 0;
+		if (source_ok)
+			peer_id_multihash_view(source_peer, &source_mh, &source_mh_len);
+		size_t message_id_len = source_mh_len + sizeof(seqno_bytes);
 		uint8_t *message_id = (uint8_t *)malloc(message_id_len);
-		int message_id_ok = (message_id != NULL);
+		int message_id_ok = (message_id != NULL && source_mh != NULL);
 		if (message_id_ok)
 		{
-			memcpy(message_id, source_peer.bytes, source_peer.size);
-			memcpy(message_id + source_peer.size, seqno_bytes, sizeof(seqno_bytes));
+			memcpy(message_id, source_mh, source_mh_len);
+			memcpy(message_id + source_mh_len, seqno_bytes, sizeof(seqno_bytes));
 		}
 		print_result("gossipsub_control_message_id_alloc", message_id_ok);
 		if (!message_id_ok)
@@ -1373,7 +1377,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 		if (subscribe_ok && ihave_ok && message_id_ok)
 		{
-			(void)libp2p_gossipsub__peer_clear_sendq(gs, &ihave_peer);
+			(void)libp2p_gossipsub__peer_clear_sendq(gs, ihave_peer);
 			uint8_t *ihave_frame = NULL;
 			size_t ihave_frame_len = 0;
 			libp2p_err_t ihave_enc = encode_control_ihave_rpc(topic_name, message_id, message_id_len,
@@ -1386,19 +1390,19 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			if (ihave_enc_ok)
 			{
 				libp2p_err_t inject_rc =
-					libp2p_gossipsub__inject_frame(gs, &ihave_peer, ihave_frame, ihave_frame_len);
+					libp2p_gossipsub__inject_frame(gs, ihave_peer, ihave_frame, ihave_frame_len);
 				int inject_ok = (inject_rc == LIBP2P_ERR_OK);
 				print_result("gossipsub_control_ihave_injected", inject_ok);
 				if (!inject_ok)
 					failures++;
 
-				size_t want_queue_len = libp2p_gossipsub__peer_sendq_len(gs, &ihave_peer);
+				size_t want_queue_len = libp2p_gossipsub__peer_sendq_len(gs, ihave_peer);
 				int want_queue_ok = (want_queue_len >= 1);
 				print_result("gossipsub_control_iwant_enqueued", want_queue_ok);
 				if (!want_queue_ok)
 					failures++;
 
-				(void)libp2p_gossipsub__peer_clear_sendq(gs, &ihave_peer);
+				(void)libp2p_gossipsub__peer_clear_sendq(gs, ihave_peer);
 				free(ihave_frame);
 			}
 		}
@@ -1410,7 +1414,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				.topic = {.struct_size = sizeof(pub_msg.topic), .topic = topic_name},
 				.data = payload,
 				.data_len = sizeof(payload),
-				.from = &source_peer,
+				.from = source_peer,
 				.seqno = seqno_bytes,
 				.seqno_len = sizeof(seqno_bytes),
 				.raw_message = NULL,
@@ -1427,7 +1431,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			if (pub_enc_ok)
 			{
 				libp2p_err_t inject_rc =
-					libp2p_gossipsub__inject_frame(gs, &source_peer, pub_frame, pub_frame_len);
+					libp2p_gossipsub__inject_frame(gs, source_peer, pub_frame, pub_frame_len);
 				int inject_ok = (inject_rc == LIBP2P_ERR_OK);
 				print_result("gossipsub_control_publish_injected", inject_ok);
 				if (!inject_ok)
@@ -1443,7 +1447,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 		if (subscribe_ok && request_ok && message_id_ok)
 		{
-			(void)libp2p_gossipsub__peer_clear_sendq(gs, &request_peer);
+			(void)libp2p_gossipsub__peer_clear_sendq(gs, request_peer);
 			uint8_t *iwant_frame = NULL;
 			size_t iwant_frame_len = 0;
 			libp2p_err_t iwant_enc =
@@ -1456,7 +1460,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			if (iwant_enc_ok)
 			{
 				libp2p_err_t inject_rc =
-					libp2p_gossipsub__inject_frame(gs, &request_peer, iwant_frame, iwant_frame_len);
+					libp2p_gossipsub__inject_frame(gs, request_peer, iwant_frame, iwant_frame_len);
 				int inject_ok = (inject_rc == LIBP2P_ERR_OK);
 				print_result("gossipsub_control_iwant_injected", inject_ok);
 				if (!inject_ok)
@@ -1465,7 +1469,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				size_t publish_queue_len = 0;
 				for (int attempt = 0; attempt < 50; ++attempt)
 				{
-					publish_queue_len = libp2p_gossipsub__peer_sendq_len(gs, &request_peer);
+					publish_queue_len = libp2p_gossipsub__peer_sendq_len(gs, request_peer);
 					if (publish_queue_len >= 1)
 						break;
 					usleep(1000);
@@ -1475,7 +1479,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				if (!publish_queue_ok)
 					failures++;
 
-				(void)libp2p_gossipsub__peer_clear_sendq(gs, &request_peer);
+				(void)libp2p_gossipsub__peer_clear_sendq(gs, request_peer);
 				free(iwant_frame);
 			}
 		}
@@ -1483,11 +1487,11 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 		if (message_id)
 			free(message_id);
 		if (request_ok)
-			peer_id_free(&request_peer);
+			peer_id_free(request_peer);
 		if (ihave_ok)
-			peer_id_free(&ihave_peer);
+			peer_id_free(ihave_peer);
 		if (source_ok)
-			peer_id_free(&source_peer);
+			peer_id_free(source_peer);
 
 		if (subscribe_ok)
 		{
@@ -1512,7 +1516,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			failures++;
 
 		const char *peer_str = "12D3KooWJDNrXxWkEJqe6D9bXqEJ8T8DMeYb49UoLxqfjZt6weu9";
-		peer_id_t throttle_peer = {0};
+		peer_id_t *throttle_peer = NULL;
 		int peer_ok = subscribe_ok && setup_gossip_peer(gs, topic_name, peer_str, &throttle_peer);
 		print_result("gossipsub_ihave_throttle_peer_setup", peer_ok);
 		if (!peer_ok && subscribe_ok)
@@ -1520,7 +1524,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 		if (peer_ok)
 		{
-			(void)libp2p_gossipsub__peer_clear_sendq(gs, &throttle_peer);
+			(void)libp2p_gossipsub__peer_clear_sendq(gs, throttle_peer);
 			for (int attempt = 0; attempt < 3; ++attempt)
 			{
 				uint8_t message_id[4] = {(uint8_t)(0x40 | attempt), 0xAA, 0x55,
@@ -1541,7 +1545,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 					break;
 				}
 
-				libp2p_err_t inj_rc = libp2p_gossipsub__inject_frame(gs, &throttle_peer, ihave_frame,
+				libp2p_err_t inj_rc = libp2p_gossipsub__inject_frame(gs, throttle_peer, ihave_frame,
 										     ihave_frame_len);
 				snprintf(label, sizeof(label), "gossipsub_ihave_throttle_inject_%d", attempt + 1);
 				int inject_ok = (inj_rc == LIBP2P_ERR_OK);
@@ -1549,14 +1553,14 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				if (!inject_ok)
 					failures++;
 
-				size_t want_queue = libp2p_gossipsub__peer_sendq_len(gs, &throttle_peer);
+				size_t want_queue = libp2p_gossipsub__peer_sendq_len(gs, throttle_peer);
 				snprintf(label, sizeof(label), "gossipsub_ihave_throttle_queue_%d", attempt + 1);
 				int expect_queue = (attempt < 2) ? (want_queue >= 1) : (want_queue == 0);
 				print_result(label, expect_queue);
 				if (!expect_queue)
 					failures++;
 
-				(void)libp2p_gossipsub__peer_clear_sendq(gs, &throttle_peer);
+				(void)libp2p_gossipsub__peer_clear_sendq(gs, throttle_peer);
 				free(ihave_frame);
 
 				if (!inject_ok)
@@ -1585,23 +1589,23 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				else
 				{
 					libp2p_err_t inj_rc = libp2p_gossipsub__inject_frame(
-						gs, &throttle_peer, ihave_frame, ihave_frame_len);
+						gs, throttle_peer, ihave_frame, ihave_frame_len);
 					int inject_ok = (inj_rc == LIBP2P_ERR_OK);
 					print_result("gossipsub_ihave_throttle_inject_post_hb", inject_ok);
 					if (!inject_ok)
 						failures++;
-					size_t want_queue = libp2p_gossipsub__peer_sendq_len(gs, &throttle_peer);
+					size_t want_queue = libp2p_gossipsub__peer_sendq_len(gs, throttle_peer);
 					int queue_ok = (want_queue >= 1);
 					print_result("gossipsub_ihave_throttle_queue_post_hb", queue_ok);
 					if (!queue_ok)
 						failures++;
-					(void)libp2p_gossipsub__peer_clear_sendq(gs, &throttle_peer);
+					(void)libp2p_gossipsub__peer_clear_sendq(gs, throttle_peer);
 				}
 				if (ihave_frame)
 					free(ihave_frame);
 			}
 
-			peer_id_free(&throttle_peer);
+			peer_id_free(throttle_peer);
 		}
 
 		if (subscribe_ok)
@@ -1635,8 +1639,8 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			const char *high_peer_str = "12D3KooWPYo9fbqHANBfChyaez2BMuL6hSwgByMkUMNjz19RMH8j";
 			const char *low_peer_str = "12D3KooWMJv9eJHRqHzU1Q5X1Mwp2vsBZ1vx3SmR5SQAiMa7QUPq";
 
-			peer_id_t high_peer = {0};
-			peer_id_t low_peer = {0};
+			peer_id_t *high_peer = NULL;
+			peer_id_t *low_peer = NULL;
 			int high_peer_ok = setup_gossip_peer(gs, topic_name, high_peer_str, &high_peer);
 			print_result("gossipsub_threshold_high_peer_setup", high_peer_ok);
 			if (!high_peer_ok)
@@ -1648,7 +1652,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 			if (high_peer_ok)
 			{
-				libp2p_err_t score_rc = libp2p_gossipsub__peer_set_score(gs, &high_peer, -0.2);
+				libp2p_err_t score_rc = libp2p_gossipsub__peer_set_score(gs, high_peer, -0.2);
 				int score_ok = (score_rc == LIBP2P_ERR_OK);
 				print_result("gossipsub_threshold_high_score", score_ok);
 				if (!score_ok)
@@ -1657,7 +1661,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 			if (low_peer_ok)
 			{
-				libp2p_err_t score_rc = libp2p_gossipsub__peer_set_score(gs, &low_peer, -0.8);
+				libp2p_err_t score_rc = libp2p_gossipsub__peer_set_score(gs, low_peer, -0.8);
 				int score_ok = (score_rc == LIBP2P_ERR_OK);
 				print_result("gossipsub_threshold_low_score", score_ok);
 				if (!score_ok)
@@ -1678,19 +1682,19 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				}
 				else
 				{
-					(void)libp2p_gossipsub__peer_clear_sendq(gs, &high_peer);
-					libp2p_err_t inj_rc = libp2p_gossipsub__inject_frame(gs, &high_peer, high_frame,
+					(void)libp2p_gossipsub__peer_clear_sendq(gs, high_peer);
+					libp2p_err_t inj_rc = libp2p_gossipsub__inject_frame(gs, high_peer, high_frame,
 											     high_frame_len);
 					int inj_ok = (inj_rc == LIBP2P_ERR_OK);
 					print_result("gossipsub_threshold_high_inject", inj_ok);
 					if (!inj_ok)
 						failures++;
-					size_t want_queue_len = libp2p_gossipsub__peer_sendq_len(gs, &high_peer);
+					size_t want_queue_len = libp2p_gossipsub__peer_sendq_len(gs, high_peer);
 					int want_ok = (want_queue_len >= 1);
 					print_result("gossipsub_threshold_high_iwant", want_ok);
 					if (!want_ok)
 						failures++;
-					(void)libp2p_gossipsub__peer_clear_sendq(gs, &high_peer);
+					(void)libp2p_gossipsub__peer_clear_sendq(gs, high_peer);
 					free(high_frame);
 				}
 			}
@@ -1709,30 +1713,30 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				}
 				else
 				{
-					(void)libp2p_gossipsub__peer_clear_sendq(gs, &low_peer);
+					(void)libp2p_gossipsub__peer_clear_sendq(gs, low_peer);
 					libp2p_err_t inj_rc =
-						libp2p_gossipsub__inject_frame(gs, &low_peer, low_frame, low_frame_len);
+						libp2p_gossipsub__inject_frame(gs, low_peer, low_frame, low_frame_len);
 					int inj_ok = (inj_rc == LIBP2P_ERR_OK);
 					print_result("gossipsub_threshold_low_inject", inj_ok);
 					if (!inj_ok)
 						failures++;
-					size_t want_queue_len = libp2p_gossipsub__peer_sendq_len(gs, &low_peer);
+					size_t want_queue_len = libp2p_gossipsub__peer_sendq_len(gs, low_peer);
 					int want_ok = (want_queue_len == 0);
 					print_result("gossipsub_threshold_low_ignored", want_ok);
 					if (!want_ok)
 						failures++;
-					(void)libp2p_gossipsub__peer_clear_sendq(gs, &low_peer);
+					(void)libp2p_gossipsub__peer_clear_sendq(gs, low_peer);
 					free(low_frame);
 				}
 			}
 
 			if (high_peer_ok)
 			{
-				peer_id_free(&high_peer);
+				peer_id_free(high_peer);
 			}
 			if (low_peer_ok)
 			{
-				peer_id_free(&low_peer);
+				peer_id_free(low_peer);
 			}
 
 			libp2p_gossipsub__set_gossip_threshold(gs, 0.0);
@@ -1761,7 +1765,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 		if (!subscribe_ok)
 			failures++;
 
-		peer_id_t gray_peer = {0};
+		peer_id_t *gray_peer = NULL;
 		const char *gray_peer_str = "12D3KooWGuG8GbdWrwT4D6L1UMxeMGLYj1A2rcEbdS3PpFo6wiU5";
 		int peer_ok = subscribe_ok && setup_gossip_peer(gs, topic_name, gray_peer_str, &gray_peer);
 		print_result("gossipsub_gray_peer_setup", peer_ok);
@@ -1774,7 +1778,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 		if (peer_ok)
 		{
 			const char *blocked_topic = "threshold/gray/blocked";
-			libp2p_err_t score_rc = libp2p_gossipsub__peer_set_score(gs, &gray_peer, -0.8);
+			libp2p_err_t score_rc = libp2p_gossipsub__peer_set_score(gs, gray_peer, -0.8);
 			int score_ok = (score_rc == LIBP2P_ERR_OK);
 			print_result("gossipsub_gray_score_set", score_ok);
 			if (!score_ok)
@@ -1791,18 +1795,18 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			}
 			else
 			{
-				(void)libp2p_gossipsub__peer_clear_sendq(gs, &gray_peer);
-				libp2p_err_t inj_rc = libp2p_gossipsub__inject_frame(gs, &gray_peer, frame, frame_len);
+				(void)libp2p_gossipsub__peer_clear_sendq(gs, gray_peer);
+				libp2p_err_t inj_rc = libp2p_gossipsub__inject_frame(gs, gray_peer, frame, frame_len);
 				int inj_ok = (inj_rc == LIBP2P_ERR_OK);
 				print_result("gossipsub_gray_inject", inj_ok);
 				if (!inj_ok)
 					failures++;
-				size_t queue_len = libp2p_gossipsub__peer_sendq_len(gs, &gray_peer);
+				size_t queue_len = libp2p_gossipsub__peer_sendq_len(gs, gray_peer);
 				int queue_ok = (queue_len == 0);
 				print_result("gossipsub_gray_sendq_empty", queue_ok);
 				if (!queue_ok)
 					failures++;
-				int subscribed = libp2p_gossipsub__peer_has_subscription(gs, &gray_peer, blocked_topic);
+				int subscribed = libp2p_gossipsub__peer_has_subscription(gs, gray_peer, blocked_topic);
 				int sub_ok = (subscribed == 0);
 				print_result("gossipsub_gray_subscription_ignored", sub_ok);
 				if (!sub_ok)
@@ -1810,8 +1814,8 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				free(frame);
 			}
 
-			(void)libp2p_gossipsub__peer_clear_sendq(gs, &gray_peer);
-			peer_id_free(&gray_peer);
+			(void)libp2p_gossipsub__peer_clear_sendq(gs, gray_peer);
+			peer_id_free(gray_peer);
 		}
 
 		libp2p_gossipsub__set_gossip_threshold(gs, 0.0);
@@ -1840,7 +1844,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			failures++;
 
 		const char *peer_str = "12D3KooWFjecZx2YM5mAZ1bn46vCeWkQS9KpVwhM2r36EJt2vqCr";
-		peer_id_t remote_peer = {0};
+		peer_id_t *remote_peer = NULL;
 		int peer_ok = (peer_id_new_from_text(peer_str, &remote_peer) == PEER_ID_OK);
 		print_result("gossipsub_graft_accept_peer_created", peer_ok);
 		if (!peer_ok)
@@ -1859,7 +1863,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			if (sub_enc_ok)
 			{
 				libp2p_err_t sub_inj =
-					libp2p_gossipsub__inject_frame(gs, &remote_peer, frame, frame_len);
+					libp2p_gossipsub__inject_frame(gs, remote_peer, frame, frame_len);
 				int sub_inj_ok = (sub_inj == LIBP2P_ERR_OK);
 				print_result("gossipsub_graft_accept_subscribe_inject", sub_inj_ok);
 				if (!sub_inj_ok)
@@ -1868,7 +1872,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			if (frame)
 				free(frame);
 
-			(void)libp2p_gossipsub__peer_clear_sendq(gs, &remote_peer);
+			(void)libp2p_gossipsub__peer_clear_sendq(gs, remote_peer);
 
 			uint8_t *graft_frame = NULL;
 			size_t graft_frame_len = 0;
@@ -1881,7 +1885,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			if (graft_enc_ok)
 			{
 				libp2p_err_t graft_inj =
-					libp2p_gossipsub__inject_frame(gs, &remote_peer, graft_frame, graft_frame_len);
+					libp2p_gossipsub__inject_frame(gs, remote_peer, graft_frame, graft_frame_len);
 				int graft_inj_ok = (graft_inj == LIBP2P_ERR_OK);
 				print_result("gossipsub_graft_accept_inject", graft_inj_ok);
 				if (!graft_inj_ok)
@@ -1896,7 +1900,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			if (!mesh_ok)
 				failures++;
 
-			size_t prune_queue = libp2p_gossipsub__peer_sendq_len(gs, &remote_peer);
+			size_t prune_queue = libp2p_gossipsub__peer_sendq_len(gs, remote_peer);
 			int prune_empty = (prune_queue == 0);
 			print_result("gossipsub_graft_accept_no_prune", prune_empty);
 			if (!prune_empty)
@@ -1913,7 +1917,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 		}
 
 		if (peer_ok)
-			peer_id_free(&remote_peer);
+			peer_id_free(remote_peer);
 	}
 
 	{
@@ -1929,7 +1933,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			failures++;
 
 		const char *peer_str = "12D3KooWDH8u1o1YiA1HXSwSReT7PwtZDs7JhdYKbnvSYnUrWhp2";
-		peer_id_t remote_peer = {0};
+		peer_id_t *remote_peer = NULL;
 		int peer_ok = (peer_id_new_from_text(peer_str, &remote_peer) == PEER_ID_OK);
 		print_result("gossipsub_graft_backoff_peer_created", peer_ok);
 		if (!peer_ok)
@@ -1948,7 +1952,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			if (sub_enc_ok)
 			{
 				libp2p_err_t sub_inj =
-					libp2p_gossipsub__inject_frame(gs, &remote_peer, frame, frame_len);
+					libp2p_gossipsub__inject_frame(gs, remote_peer, frame, frame_len);
 				int sub_inj_ok = (sub_inj == LIBP2P_ERR_OK);
 				print_result("gossipsub_graft_backoff_subscribe_inject", sub_inj_ok);
 				if (!sub_inj_ok)
@@ -1957,7 +1961,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			if (frame)
 				free(frame);
 
-			(void)libp2p_gossipsub__peer_clear_sendq(gs, &remote_peer);
+			(void)libp2p_gossipsub__peer_clear_sendq(gs, remote_peer);
 
 			uint8_t *graft_frame = NULL;
 			size_t graft_frame_len = 0;
@@ -1970,7 +1974,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			if (graft_enc_ok)
 			{
 				libp2p_err_t graft_inj =
-					libp2p_gossipsub__inject_frame(gs, &remote_peer, graft_frame, graft_frame_len);
+					libp2p_gossipsub__inject_frame(gs, remote_peer, graft_frame, graft_frame_len);
 				int graft_inj_ok = (graft_inj == LIBP2P_ERR_OK);
 				print_result("gossipsub_graft_backoff_graft_inject", graft_inj_ok);
 				if (!graft_inj_ok)
@@ -1996,7 +2000,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			if (prune_enc_ok)
 			{
 				libp2p_err_t prune_inj =
-					libp2p_gossipsub__inject_frame(gs, &remote_peer, prune_frame, prune_frame_len);
+					libp2p_gossipsub__inject_frame(gs, remote_peer, prune_frame, prune_frame_len);
 				int prune_inj_ok = (prune_inj == LIBP2P_ERR_OK);
 				print_result("gossipsub_graft_backoff_prune_inject", prune_inj_ok);
 				if (!prune_inj_ok)
@@ -2011,12 +2015,12 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			if (!mesh_cleared)
 				failures++;
 
-			int backoff_present = libp2p_gossipsub__topic_backoff_contains(gs, topic_name, &remote_peer);
+			int backoff_present = libp2p_gossipsub__topic_backoff_contains(gs, topic_name, remote_peer);
 			print_result("gossipsub_graft_backoff_recorded", backoff_present);
 			if (!backoff_present)
 				failures++;
 
-			(void)libp2p_gossipsub__peer_clear_sendq(gs, &remote_peer);
+			(void)libp2p_gossipsub__peer_clear_sendq(gs, remote_peer);
 
 			uint8_t *second_graft = NULL;
 			size_t second_graft_len = 0;
@@ -2028,7 +2032,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 			if (second_enc_ok)
 			{
-				libp2p_err_t second_inj = libp2p_gossipsub__inject_frame(gs, &remote_peer, second_graft,
+				libp2p_err_t second_inj = libp2p_gossipsub__inject_frame(gs, remote_peer, second_graft,
 											 second_graft_len);
 				int second_inj_ok = (second_inj == LIBP2P_ERR_OK);
 				print_result("gossipsub_graft_backoff_second_inject", second_inj_ok);
@@ -2038,7 +2042,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			if (second_graft)
 				free(second_graft);
 
-			size_t prune_queue = libp2p_gossipsub__peer_sendq_len(gs, &remote_peer);
+			size_t prune_queue = libp2p_gossipsub__peer_sendq_len(gs, remote_peer);
 			int prune_enqueued = (prune_queue >= 1);
 			print_result("gossipsub_graft_backoff_prune_enqueued", prune_enqueued);
 			if (!prune_enqueued)
@@ -2047,7 +2051,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			uint8_t *queued_frame = NULL;
 			size_t queued_len = 0;
 			libp2p_err_t pop_rc =
-				libp2p_gossipsub__peer_pop_sendq(gs, &remote_peer, &queued_frame, &queued_len);
+				libp2p_gossipsub__peer_pop_sendq(gs, remote_peer, &queued_frame, &queued_len);
 			int pop_ok = (pop_rc == LIBP2P_ERR_OK && queued_frame && queued_len);
 			print_result("gossipsub_graft_backoff_prune_popped", pop_ok);
 			if (!pop_ok)
@@ -2147,7 +2151,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 		}
 
 		if (peer_ok)
-			peer_id_free(&remote_peer);
+			peer_id_free(remote_peer);
 	}
 
 	{
@@ -2172,8 +2176,8 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 			const char *flood_high_str = "12D3KooWExgVnyL9F9ktsHTTXV9cZ6rxWPPPwJ9V6u3yyFvEfYst";
 			const char *flood_low_str = "12D3KooWFjecZx2YM5mAZ1bn46vCeWkQS9KpVwhM2r36EJt2vqCr";
-			peer_id_t flood_high = {0};
-			peer_id_t flood_low = {0};
+			peer_id_t *flood_high = NULL;
+			peer_id_t *flood_low = NULL;
 			int high_peer_ok = setup_gossip_peer(gs, flood_topic_name, flood_high_str, &flood_high);
 			int low_peer_ok = setup_gossip_peer(gs, flood_topic_name, flood_low_str, &flood_low);
 			print_result("gossipsub_flood_high_peer_setup", high_peer_ok);
@@ -2204,22 +2208,22 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 				if (flood_pub1_ok)
 				{
 					int high_received_initial =
-						gossipsub_wait_for_peer_frame(gs, &flood_high, 1000, NULL);
+						gossipsub_wait_for_peer_frame(gs, flood_high, 1000, NULL);
 					int low_received_initial =
-						gossipsub_wait_for_peer_frame(gs, &flood_low, 1000, NULL);
+						gossipsub_wait_for_peer_frame(gs, flood_low, 1000, NULL);
 					int flood_all_receive = (high_received_initial && low_received_initial);
 					print_result("gossipsub_flood_all_peers_receive", flood_all_receive);
 					if (!flood_all_receive)
 						failures++;
-					(void)gossipsub_wait_for_peer_idle(gs, &flood_high, 200, NULL);
-					(void)gossipsub_wait_for_peer_idle(gs, &flood_low, 200, NULL);
-					(void)libp2p_gossipsub__peer_clear_sendq(gs, &flood_high);
-					(void)libp2p_gossipsub__peer_clear_sendq(gs, &flood_low);
+					(void)gossipsub_wait_for_peer_idle(gs, flood_high, 200, NULL);
+					(void)gossipsub_wait_for_peer_idle(gs, flood_low, 200, NULL);
+					(void)libp2p_gossipsub__peer_clear_sendq(gs, flood_high);
+					(void)libp2p_gossipsub__peer_clear_sendq(gs, flood_low);
 				}
 
 				libp2p_gossipsub__topic_set_publish_threshold(gs, flood_topic_name, 0.75);
-				(void)libp2p_gossipsub__peer_set_score(gs, &flood_high, 1.0);
-				(void)libp2p_gossipsub__peer_set_score(gs, &flood_low, 0.0);
+				(void)libp2p_gossipsub__peer_set_score(gs, flood_high, 1.0);
+				(void)libp2p_gossipsub__peer_set_score(gs, flood_low, 0.0);
 
 				uint8_t flood_payload2[] = {0xF2, 0x01, 0x02};
 				libp2p_gossipsub_message_t flood_msg2 = {
@@ -2239,23 +2243,23 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 				if (flood_pub2_ok)
 				{
-					int high_received = gossipsub_wait_for_peer_frame(gs, &flood_high, 1000, NULL);
+					int high_received = gossipsub_wait_for_peer_frame(gs, flood_high, 1000, NULL);
 					size_t low_queue = 0;
 					int low_stayed_empty =
-						gossipsub_wait_for_peer_idle(gs, &flood_low, 200, &low_queue);
+						gossipsub_wait_for_peer_idle(gs, flood_low, 200, &low_queue);
 					int flood_threshold_enforced =
 						(high_received && low_stayed_empty && low_queue == 0);
 					print_result("gossipsub_flood_threshold_enforced", flood_threshold_enforced);
 					if (!flood_threshold_enforced)
 						failures++;
-					(void)libp2p_gossipsub__peer_clear_sendq(gs, &flood_high);
-					(void)libp2p_gossipsub__peer_clear_sendq(gs, &flood_low);
+					(void)libp2p_gossipsub__peer_clear_sendq(gs, flood_high);
+					(void)libp2p_gossipsub__peer_clear_sendq(gs, flood_low);
 				}
 
-				(void)libp2p_gossipsub__peer_set_score(gs, &flood_high, 0.0);
-				(void)libp2p_gossipsub__peer_set_score(gs, &flood_low, 0.0);
-				peer_id_free(&flood_high);
-				peer_id_free(&flood_low);
+				(void)libp2p_gossipsub__peer_set_score(gs, flood_high, 0.0);
+				(void)libp2p_gossipsub__peer_set_score(gs, flood_low, 0.0);
+				peer_id_free(flood_high);
+				peer_id_free(flood_low);
 			}
 
 			libp2p_gossipsub__set_flood_publish(gs, 0);
@@ -2291,14 +2295,14 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 		const double mesh_scores[] = {-0.2, 0.0, 0.1};
 		const int mesh_outbound[] = {1, 0, 0};
 		const size_t mesh_count = sizeof(mesh_ids) / sizeof(mesh_ids[0]);
-		peer_id_t mesh_peers[sizeof(mesh_ids) / sizeof(mesh_ids[0])];
+		peer_id_t *mesh_peers[sizeof(mesh_ids) / sizeof(mesh_ids[0])];
 		memset(mesh_peers, 0, sizeof(mesh_peers));
 
 		const char *candidate_ids[] = {"12D3KooWJwKkHy2W2Ck3RyAEJgVhtSGcVwqDAVBBusZT6F4LmSpa",
 					       "12D3KooWBxkU3YdrNBwCYwiVdcgGqzGwdrDam6DCeU44y7Nys8KM"};
 		const double candidate_scores[] = {1.2, 0.9};
 		const size_t candidate_count = sizeof(candidate_ids) / sizeof(candidate_ids[0]);
-		peer_id_t candidate_peers[sizeof(candidate_ids) / sizeof(candidate_ids[0])];
+		peer_id_t *candidate_peers[sizeof(candidate_ids) / sizeof(candidate_ids[0])];
 		memset(candidate_peers, 0, sizeof(candidate_peers));
 
 		int mesh_setup_ok = subscribe_ok;
@@ -2311,13 +2315,13 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 					mesh_setup_ok = 0;
 					break;
 				}
-				if (libp2p_gossipsub__peer_set_score(gs, &mesh_peers[i], mesh_scores[i]) !=
+				if (libp2p_gossipsub__peer_set_score(gs, mesh_peers[i], mesh_scores[i]) !=
 				    LIBP2P_ERR_OK)
 				{
 					mesh_setup_ok = 0;
 					break;
 				}
-				if (libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, &mesh_peers[i],
+				if (libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, mesh_peers[i],
 									  mesh_outbound[i]) != LIBP2P_ERR_OK)
 				{
 					mesh_setup_ok = 0;
@@ -2339,7 +2343,7 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 					candidate_setup_ok = 0;
 					break;
 				}
-				if (libp2p_gossipsub__peer_set_score(gs, &candidate_peers[i], candidate_scores[i]) !=
+				if (libp2p_gossipsub__peer_set_score(gs, candidate_peers[i], candidate_scores[i]) !=
 				    LIBP2P_ERR_OK)
 				{
 					candidate_setup_ok = 0;
@@ -2363,14 +2367,14 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			if (prune_enc_ok)
 			{
 				libp2p_err_t prune_inj =
-					libp2p_gossipsub__inject_frame(gs, &candidate_peers[0], prune_buf, prune_len);
+					libp2p_gossipsub__inject_frame(gs, candidate_peers[0], prune_buf, prune_len);
 				prune_inj_ok = (prune_inj == LIBP2P_ERR_OK);
 			}
 			if (prune_buf)
 				free(prune_buf);
 			if (prune_inj_ok)
 				backoff_seeded =
-					libp2p_gossipsub__topic_backoff_contains(gs, topic_name, &candidate_peers[0]);
+					libp2p_gossipsub__topic_backoff_contains(gs, topic_name, candidate_peers[0]);
 		}
 		print_result("gossipsub_opportunistic_prune_encode", prune_enc_ok);
 		if (!prune_enc_ok)
@@ -2412,12 +2416,12 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 			for (size_t i = 0; i < candidate_count; ++i)
 			{
 				candidate_mesh_ok[i] = libp2p_gossipsub__topic_mesh_contains(
-					gs, topic_name, &candidate_peers[i], NULL, NULL);
-				size_t sendq_len = libp2p_gossipsub__peer_sendq_len(gs, &candidate_peers[i]);
+					gs, topic_name, candidate_peers[i], NULL, NULL);
+				size_t sendq_len = libp2p_gossipsub__peer_sendq_len(gs, candidate_peers[i]);
 				candidate_sendq_ok[i] = (sendq_len > 0);
 			}
 			backoff_cleared =
-				(libp2p_gossipsub__topic_backoff_contains(gs, topic_name, &candidate_peers[0]) == 0);
+				(libp2p_gossipsub__topic_backoff_contains(gs, topic_name, candidate_peers[0]) == 0);
 		}
 
 		print_result("gossipsub_opportunistic_mesh_growth", mesh_growth_ok);
@@ -2443,11 +2447,11 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 		for (size_t i = 0; i < candidate_count; ++i)
 		{
-			while (libp2p_gossipsub__peer_sendq_len(gs, &candidate_peers[i]) > 0)
+			while (libp2p_gossipsub__peer_sendq_len(gs, candidate_peers[i]) > 0)
 			{
 				uint8_t *tmp_buf = NULL;
 				size_t tmp_len = 0;
-				libp2p_gossipsub__peer_pop_sendq(gs, &candidate_peers[i], &tmp_buf, &tmp_len);
+				libp2p_gossipsub__peer_pop_sendq(gs, candidate_peers[i], &tmp_buf, &tmp_len);
 				if (tmp_buf)
 					free(tmp_buf);
 			}
@@ -2455,15 +2459,15 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 		for (size_t i = 0; i < candidate_count; ++i)
 		{
-			(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, &candidate_peers[i]);
-			(void)libp2p_gossipsub__peer_clear_sendq(gs, &candidate_peers[i]);
-			(void)libp2p_gossipsub__peer_set_connected(gs, &candidate_peers[i], 0);
+			(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, candidate_peers[i]);
+			(void)libp2p_gossipsub__peer_clear_sendq(gs, candidate_peers[i]);
+			(void)libp2p_gossipsub__peer_set_connected(gs, candidate_peers[i], 0);
 		}
 		for (size_t i = 0; i < mesh_count; ++i)
 		{
-			(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, &mesh_peers[i]);
-			(void)libp2p_gossipsub__peer_clear_sendq(gs, &mesh_peers[i]);
-			(void)libp2p_gossipsub__peer_set_connected(gs, &mesh_peers[i], 0);
+			(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, mesh_peers[i]);
+			(void)libp2p_gossipsub__peer_clear_sendq(gs, mesh_peers[i]);
+			(void)libp2p_gossipsub__peer_set_connected(gs, mesh_peers[i], 0);
 		}
 
 		if (subscribe_ok)
@@ -2482,13 +2486,13 @@ int gossipsub_service_run_px_and_opportunistic_tests(gossipsub_service_test_env_
 
 		for (size_t i = 0; i < candidate_count; ++i)
 		{
-			if (candidate_peers[i].bytes)
-				peer_id_free(&candidate_peers[i]);
+			if (candidate_peers[i])
+				peer_id_free(candidate_peers[i]);
 		}
 		for (size_t i = 0; i < mesh_count; ++i)
 		{
-			if (mesh_peers[i].bytes)
-				peer_id_free(&mesh_peers[i]);
+			if (mesh_peers[i])
+				peer_id_free(mesh_peers[i]);
 		}
 	}
 

--- a/tests/protocol/gossipsub/test_gossipsub_service_scoring.c
+++ b/tests/protocol/gossipsub/test_gossipsub_service_scoring.c
@@ -31,8 +31,8 @@ static int run_ip_colocation_test(gossipsub_service_test_env_t *env)
 
 	const char *peer_a_str = "12D3KooWKihXhd6hExP1dcrQom7uxVkxrSF7CXQQqiweRCLFLACn";
 	const char *peer_b_str = "12D3KooWPyUCDV3zLh3yfrBh7ku19gt1rjYPdByJ72kX3HY4cGJm";
-	peer_id_t peer_a = {0};
-	peer_id_t peer_b = {0};
+	peer_id_t *peer_a = NULL;
+	peer_id_t *peer_b = NULL;
 	int peer_a_ok = setup_gossip_peer(gs, topic_name, peer_a_str, &peer_a);
 	print_result("gossipsub_score_ip_colocation_peer_a", peer_a_ok);
 	if (!peer_a_ok)
@@ -46,8 +46,8 @@ static int run_ip_colocation_test(gossipsub_service_test_env_t *env)
 
 	if (peer_a_ok && peer_b_ok)
 	{
-		libp2p_err_t set_a_rc = libp2p_gossipsub__peer_set_remote_ip(gs, &peer_a, "192.0.2.10");
-		libp2p_err_t set_b_rc = libp2p_gossipsub__peer_set_remote_ip(gs, &peer_b, "192.0.2.10");
+		libp2p_err_t set_a_rc = libp2p_gossipsub__peer_set_remote_ip(gs, peer_a, "192.0.2.10");
+		libp2p_err_t set_b_rc = libp2p_gossipsub__peer_set_remote_ip(gs, peer_b, "192.0.2.10");
 		int set_a_ok = (set_a_rc == LIBP2P_ERR_OK);
 		int set_b_ok = (set_b_rc == LIBP2P_ERR_OK);
 		print_result("gossipsub_score_ip_colocation_set_a", set_a_ok);
@@ -61,8 +61,8 @@ static int run_ip_colocation_test(gossipsub_service_test_env_t *env)
 		{
 			(void)libp2p_gossipsub__heartbeat(gs);
 			double expected_penalty = env->cfg.ip_colocation_weight * 1.0;
-			double score_a = libp2p_gossipsub__peer_get_score(gs, &peer_a, NULL);
-			double score_b = libp2p_gossipsub__peer_get_score(gs, &peer_b, NULL);
+			double score_a = libp2p_gossipsub__peer_get_score(gs, peer_a, NULL);
+			double score_b = libp2p_gossipsub__peer_get_score(gs, peer_b, NULL);
 			int penalty_a_ok = (fabs(score_a - expected_penalty) < 1e-6);
 			int penalty_b_ok = (fabs(score_b - expected_penalty) < 1e-6);
 			print_result("gossipsub_score_ip_colocation_penalty_a", penalty_a_ok);
@@ -72,7 +72,7 @@ static int run_ip_colocation_test(gossipsub_service_test_env_t *env)
 			if (!penalty_b_ok)
 				failures++;
 
-			libp2p_err_t reset_b_rc = libp2p_gossipsub__peer_set_remote_ip(gs, &peer_b, "198.51.100.20");
+			libp2p_err_t reset_b_rc = libp2p_gossipsub__peer_set_remote_ip(gs, peer_b, "198.51.100.20");
 			int reset_b_ok = (reset_b_rc == LIBP2P_ERR_OK);
 			print_result("gossipsub_score_ip_colocation_reset_b", reset_b_ok);
 			if (!reset_b_ok)
@@ -81,8 +81,8 @@ static int run_ip_colocation_test(gossipsub_service_test_env_t *env)
 			if (reset_b_ok)
 			{
 				(void)libp2p_gossipsub__heartbeat(gs);
-				double score_a_after = libp2p_gossipsub__peer_get_score(gs, &peer_a, NULL);
-				double score_b_after = libp2p_gossipsub__peer_get_score(gs, &peer_b, NULL);
+				double score_a_after = libp2p_gossipsub__peer_get_score(gs, peer_a, NULL);
+				double score_b_after = libp2p_gossipsub__peer_get_score(gs, peer_b, NULL);
 				int cleared_a_ok = (fabs(score_a_after) < 1e-6);
 				int cleared_b_ok = (fabs(score_b_after) < 1e-6);
 				print_result("gossipsub_score_ip_colocation_clear_a", cleared_a_ok);
@@ -94,10 +94,10 @@ static int run_ip_colocation_test(gossipsub_service_test_env_t *env)
 			}
 		}
 
-		(void)libp2p_gossipsub__peer_clear_sendq(gs, &peer_a);
-		(void)libp2p_gossipsub__peer_clear_sendq(gs, &peer_b);
-		(void)libp2p_gossipsub__peer_set_connected(gs, &peer_a, 0);
-		(void)libp2p_gossipsub__peer_set_connected(gs, &peer_b, 0);
+		(void)libp2p_gossipsub__peer_clear_sendq(gs, peer_a);
+		(void)libp2p_gossipsub__peer_clear_sendq(gs, peer_b);
+		(void)libp2p_gossipsub__peer_set_connected(gs, peer_a, 0);
+		(void)libp2p_gossipsub__peer_set_connected(gs, peer_b, 0);
 	}
 
 	if (subscribe_ok)
@@ -110,9 +110,9 @@ static int run_ip_colocation_test(gossipsub_service_test_env_t *env)
 	}
 
 	if (peer_a_ok)
-		peer_id_free(&peer_a);
+		peer_id_free(peer_a);
 	if (peer_b_ok)
-		peer_id_free(&peer_b);
+		peer_id_free(peer_b);
 
 	return failures;
 }
@@ -146,8 +146,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 			failures++;
 
 		const char *peer_str = "12D3KooWRbYFJd8hVZCqxx1Zt9KJ9kzPWxtLs5FoX4iVQQPPrw3Y";
-		peer_id_t score_peer;
-		memset(&score_peer, 0, sizeof(score_peer));
+		peer_id_t *score_peer = NULL;
 		int peer_ok = 0;
 		if (subscribe_ok)
 			peer_ok = setup_gossip_peer(gs, topic_name, peer_str, &score_peer);
@@ -157,13 +156,13 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 
 		if (subscribe_ok && peer_ok)
 		{
-			libp2p_err_t mesh_rc = libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, &score_peer, 1);
+			libp2p_err_t mesh_rc = libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, score_peer, 1);
 			int mesh_ok = (mesh_rc == LIBP2P_ERR_OK);
 			print_result("gossipsub_score_mesh_add", mesh_ok);
 			if (!mesh_ok)
 				failures++;
 
-			double initial_score = libp2p_gossipsub__peer_get_score(gs, &score_peer, NULL);
+			double initial_score = libp2p_gossipsub__peer_get_score(gs, score_peer, NULL);
 			int initial_ok = (initial_score >= -1e-6 && initial_score <= 1e-6);
 			print_result("gossipsub_score_initial_zero", initial_ok);
 			if (!initial_ok)
@@ -171,7 +170,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 
 			usleep(20000);
 			libp2p_gossipsub__heartbeat(gs);
-			double score_first = libp2p_gossipsub__peer_get_score(gs, &score_peer, NULL);
+			double score_first = libp2p_gossipsub__peer_get_score(gs, score_peer, NULL);
 			int positive_ok = (score_first > 0.0);
 			print_result("gossipsub_score_positive", positive_ok);
 			if (!positive_ok)
@@ -179,26 +178,26 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 
 			usleep(20000);
 			libp2p_gossipsub__heartbeat(gs);
-			double score_second = libp2p_gossipsub__peer_get_score(gs, &score_peer, NULL);
+			double score_second = libp2p_gossipsub__peer_get_score(gs, score_peer, NULL);
 			int increasing_ok = (score_second > score_first);
 			print_result("gossipsub_score_increasing", increasing_ok);
 			if (!increasing_ok)
 				failures++;
 
-			libp2p_err_t remove_rc = libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, &score_peer);
+			libp2p_err_t remove_rc = libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, score_peer);
 			int remove_ok = (remove_rc == LIBP2P_ERR_OK);
 			print_result("gossipsub_score_mesh_remove", remove_ok);
 			if (!remove_ok)
 				failures++;
 
 			libp2p_gossipsub__heartbeat(gs);
-			double score_removed = libp2p_gossipsub__peer_get_score(gs, &score_peer, NULL);
+			double score_removed = libp2p_gossipsub__peer_get_score(gs, score_peer, NULL);
 			int reset_ok = (score_removed >= -1e-6 && score_removed <= 0.05);
 			print_result("gossipsub_score_reset", reset_ok);
 			if (!reset_ok)
 				failures++;
 
-			libp2p_err_t override_rc = libp2p_gossipsub__peer_set_score(gs, &score_peer, 5.0);
+			libp2p_err_t override_rc = libp2p_gossipsub__peer_set_score(gs, score_peer, 5.0);
 			int override_set_ok = (override_rc == LIBP2P_ERR_OK);
 			print_result("gossipsub_score_override_set", override_set_ok);
 			if (!override_set_ok)
@@ -207,15 +206,15 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 			usleep(10000);
 			libp2p_gossipsub__heartbeat(gs);
 			int override_flag = 0;
-			double override_score = libp2p_gossipsub__peer_get_score(gs, &score_peer, &override_flag);
+			double override_score = libp2p_gossipsub__peer_get_score(gs, score_peer, &override_flag);
 			int override_ok = (override_flag == 1 && override_score >= 4.9 && override_score <= 5.1);
 			print_result("gossipsub_score_override_persist", override_ok);
 			if (!override_ok)
 				failures++;
 
-			(void)libp2p_gossipsub__peer_set_score(gs, &score_peer, 0.0);
-			(void)libp2p_gossipsub__peer_clear_sendq(gs, &score_peer);
-			libp2p_gossipsub__peer_set_connected(gs, &score_peer, 0);
+			(void)libp2p_gossipsub__peer_set_score(gs, score_peer, 0.0);
+			(void)libp2p_gossipsub__peer_clear_sendq(gs, score_peer);
+			libp2p_gossipsub__peer_set_connected(gs, score_peer, 0);
 		}
 
 		if (subscribe_ok)
@@ -233,7 +232,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 		}
 
 		if (peer_ok)
-			peer_id_free(&score_peer);
+			peer_id_free(score_peer);
 	}
 
 	{
@@ -250,7 +249,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 			failures++;
 
 		const char *peer_str = "12D3KooWLL8sR3cQoQ1Mo3eLKP9whXphJEG9wZb5G1fWQYTTK91S";
-		peer_id_t op_peer = {0};
+		peer_id_t *op_peer = NULL;
 		int peer_ok = 0;
 		if (subscribe_ok)
 			peer_ok = setup_gossip_peer(gs, topic_name, peer_str, &op_peer);
@@ -262,13 +261,13 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 		{
 			int base_updates = env->score_update_count;
 			double desired_score = 2.5;
-			libp2p_err_t op_rc = libp2p_gossipsub_set_peer_application_score(gs, &op_peer, desired_score);
+			libp2p_err_t op_rc = libp2p_gossipsub_set_peer_application_score(gs, op_peer, desired_score);
 			int application_set_ok = (op_rc == LIBP2P_ERR_OK);
 			print_result("gossipsub_score_operator_application_set", application_set_ok);
 			if (!application_set_ok)
 				failures++;
 
-			double score_after_set = libp2p_gossipsub__peer_get_score(gs, &op_peer, NULL);
+			double score_after_set = libp2p_gossipsub__peer_get_score(gs, op_peer, NULL);
 			int application_value_ok = (fabs(score_after_set - desired_score) < 1e-6);
 			print_result("gossipsub_score_operator_application_value", application_value_ok);
 			if (!application_value_ok)
@@ -282,13 +281,13 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 
 			base_updates = env->score_update_count;
 			double penalty_delta = 1.25;
-			op_rc = libp2p_gossipsub_add_peer_behaviour_penalty(gs, &op_peer, penalty_delta);
+			op_rc = libp2p_gossipsub_add_peer_behaviour_penalty(gs, op_peer, penalty_delta);
 			int penalty_add_ok = (op_rc == LIBP2P_ERR_OK);
 			print_result("gossipsub_score_operator_penalty_add", penalty_add_ok);
 			if (!penalty_add_ok)
 				failures++;
 
-			double score_after_penalty = libp2p_gossipsub__peer_get_score(gs, &op_peer, NULL);
+			double score_after_penalty = libp2p_gossipsub__peer_get_score(gs, op_peer, NULL);
 			double penalty_weight = env->cfg.behaviour_penalty_weight;
 			double expected_penalty_score =
 				desired_score + penalty_weight * (penalty_delta * penalty_delta);
@@ -304,13 +303,13 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 				failures++;
 
 			base_updates = env->score_update_count;
-			op_rc = libp2p_gossipsub_set_peer_behaviour_penalty(gs, &op_peer, 0.0);
+			op_rc = libp2p_gossipsub_set_peer_behaviour_penalty(gs, op_peer, 0.0);
 			int penalty_reset_ok = (op_rc == LIBP2P_ERR_OK);
 			print_result("gossipsub_score_operator_penalty_reset", penalty_reset_ok);
 			if (!penalty_reset_ok)
 				failures++;
 
-			double score_after_reset = libp2p_gossipsub__peer_get_score(gs, &op_peer, NULL);
+			double score_after_reset = libp2p_gossipsub__peer_get_score(gs, op_peer, NULL);
 			int penalty_reset_value_ok = (fabs(score_after_reset - desired_score) < 1e-6);
 			print_result("gossipsub_score_operator_penalty_reset_value", penalty_reset_value_ok);
 			if (!penalty_reset_value_ok)
@@ -323,7 +322,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 				failures++;
 
 			base_updates = env->score_update_count;
-			libp2p_err_t override_rc = libp2p_gossipsub__peer_set_score(gs, &op_peer, 4.0);
+			libp2p_err_t override_rc = libp2p_gossipsub__peer_set_score(gs, op_peer, 4.0);
 			int override_ok = (override_rc == LIBP2P_ERR_OK);
 			print_result("gossipsub_score_operator_override_set", override_ok);
 			if (!override_ok)
@@ -337,14 +336,14 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 				failures++;
 
 			base_updates = env->score_update_count;
-			(void)libp2p_gossipsub__peer_clear_score_override(gs, &op_peer);
+			(void)libp2p_gossipsub__peer_clear_score_override(gs, op_peer);
 			(void)libp2p_gossipsub__heartbeat(gs);
 			int override_clear_callback_ok =
 				(env->score_update_count >= base_updates + 1) && (env->score_update_last_override == 0);
 			print_result("gossipsub_score_operator_override_clear_callback", override_clear_callback_ok);
 			if (!override_clear_callback_ok)
 				failures++;
-			double score_post_clear = libp2p_gossipsub__peer_get_score(gs, &op_peer, NULL);
+			double score_post_clear = libp2p_gossipsub__peer_get_score(gs, op_peer, NULL);
 			int override_clear_value_ok = (fabs(score_post_clear - desired_score) < 1e-6);
 			print_result("gossipsub_score_operator_override_cleared", override_clear_value_ok);
 			if (!override_clear_value_ok)
@@ -366,7 +365,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 		}
 
 		if (peer_ok)
-			peer_id_free(&op_peer);
+			peer_id_free(op_peer);
 	}
 
 	{
@@ -399,7 +398,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 			failures++;
 
 		const char *peer_str = "12D3KooWNhqcS8N5cCw6mU4esDaS6XdZWQU3oS9LFCH4x4ETyCQT";
-		peer_id_t first_peer = {0};
+		peer_id_t *first_peer = NULL;
 		int peer_ok = 0;
 		if (subscribe_ok)
 			peer_ok = setup_gossip_peer(gs, topic_name, peer_str, &first_peer);
@@ -409,7 +408,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 
 		if (subscribe_ok && peer_ok)
 		{
-			libp2p_err_t mesh_rc = libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, &first_peer, 1);
+			libp2p_err_t mesh_rc = libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, first_peer, 1);
 			int mesh_ok = (mesh_rc == LIBP2P_ERR_OK);
 			print_result("gossipsub_score_first_delivery_mesh_add", mesh_ok);
 			if (!mesh_ok)
@@ -423,7 +422,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 					.topic = {.struct_size = sizeof(first_msg.topic), .topic = topic_name},
 					.data = payload,
 					.data_len = sizeof(payload),
-					.from = &first_peer,
+					.from = first_peer,
 					.seqno = seqno,
 					.seqno_len = sizeof(seqno),
 					.raw_message = NULL,
@@ -441,7 +440,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 				if (encode_ok)
 				{
 					libp2p_err_t inj_rc =
-						libp2p_gossipsub__inject_frame(gs, &first_peer, frame, frame_len);
+						libp2p_gossipsub__inject_frame(gs, first_peer, frame, frame_len);
 					int inject_ok = (inj_rc == LIBP2P_ERR_OK);
 					print_result("gossipsub_score_first_delivery_inject", inject_ok);
 					if (!inject_ok)
@@ -449,7 +448,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 					else
 					{
 						usleep(10000);
-						double score = libp2p_gossipsub__peer_get_score(gs, &first_peer, NULL);
+						double score = libp2p_gossipsub__peer_get_score(gs, first_peer, NULL);
 						int score_ok = (score > 0.0);
 						print_result("gossipsub_score_first_delivery_positive", score_ok);
 						if (!score_ok)
@@ -461,9 +460,9 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 					free(frame);
 			}
 
-			(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, &first_peer);
-			(void)libp2p_gossipsub__peer_clear_sendq(gs, &first_peer);
-			(void)libp2p_gossipsub__peer_set_connected(gs, &first_peer, 0);
+			(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, first_peer);
+			(void)libp2p_gossipsub__peer_clear_sendq(gs, first_peer);
+			(void)libp2p_gossipsub__peer_set_connected(gs, first_peer, 0);
 		}
 
 		if (subscribe_ok)
@@ -481,7 +480,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 		}
 
 		if (peer_ok)
-			peer_id_free(&first_peer);
+			peer_id_free(first_peer);
 	}
 
 	{
@@ -514,7 +513,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 			failures++;
 
 		const char *peer_str = "12D3KooWHZjVdysJ8V5Y2Tyshzw31wY1M2fjTw83YVHC6rU1ttzv";
-		peer_id_t mesh_peer = {0};
+		peer_id_t *mesh_peer = NULL;
 		int peer_ok = 0;
 		if (subscribe_ok)
 			peer_ok = setup_gossip_peer(gs, topic_name, peer_str, &mesh_peer);
@@ -524,8 +523,8 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 
 		if (subscribe_ok && peer_ok)
 		{
-			(void)libp2p_gossipsub__peer_clear_score_override(gs, &mesh_peer);
-			libp2p_err_t mesh_rc = libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, &mesh_peer, 1);
+			(void)libp2p_gossipsub__peer_clear_score_override(gs, mesh_peer);
+			libp2p_err_t mesh_rc = libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, mesh_peer, 1);
 			int mesh_ok = (mesh_rc == LIBP2P_ERR_OK);
 			print_result("gossipsub_score_mesh_penalty_mesh_add", mesh_ok);
 			if (!mesh_ok)
@@ -534,16 +533,16 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 			if (mesh_ok)
 			{
 				libp2p_gossipsub__heartbeat(gs);
-				double score = libp2p_gossipsub__peer_get_score(gs, &mesh_peer, NULL);
+				double score = libp2p_gossipsub__peer_get_score(gs, mesh_peer, NULL);
 				int penalty_ok = (score < -0.5);
 				print_result("gossipsub_score_mesh_penalty_negative", penalty_ok);
 				if (!penalty_ok)
 					failures++;
 			}
 
-			(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, &mesh_peer);
-			(void)libp2p_gossipsub__peer_clear_sendq(gs, &mesh_peer);
-			(void)libp2p_gossipsub__peer_set_connected(gs, &mesh_peer, 0);
+			(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, mesh_peer);
+			(void)libp2p_gossipsub__peer_clear_sendq(gs, mesh_peer);
+			(void)libp2p_gossipsub__peer_set_connected(gs, mesh_peer, 0);
 		}
 
 		if (subscribe_ok)
@@ -561,7 +560,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 		}
 
 		if (peer_ok)
-			peer_id_free(&mesh_peer);
+			peer_id_free(mesh_peer);
 	}
 
 	{
@@ -594,7 +593,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 			failures++;
 
 		const char *peer_str = "12D3KooWQX1pP6uPQ7RZicMv6z4dGYBHc9B7iKLB9gowgCJFzQEw";
-		peer_id_t failure_peer = {0};
+		peer_id_t *failure_peer = NULL;
 		int peer_ok = 0;
 		if (subscribe_ok)
 			peer_ok = setup_gossip_peer(gs, topic_name, peer_str, &failure_peer);
@@ -604,8 +603,8 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 
 		if (subscribe_ok && peer_ok)
 		{
-			(void)libp2p_gossipsub__peer_clear_score_override(gs, &failure_peer);
-			libp2p_err_t mesh_rc = libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, &failure_peer, 1);
+			(void)libp2p_gossipsub__peer_clear_score_override(gs, failure_peer);
+			libp2p_err_t mesh_rc = libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, failure_peer, 1);
 			int mesh_ok = (mesh_rc == LIBP2P_ERR_OK);
 			print_result("gossipsub_score_failure_penalty_mesh_add", mesh_ok);
 			if (!mesh_ok)
@@ -614,28 +613,28 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 			if (mesh_ok)
 			{
 				libp2p_gossipsub__heartbeat(gs);
-				double score_before = libp2p_gossipsub__peer_get_score(gs, &failure_peer, NULL);
+				double score_before = libp2p_gossipsub__peer_get_score(gs, failure_peer, NULL);
 				int negative_ok = (score_before < -1.0);
 				print_result("gossipsub_score_failure_penalty_negative_before", negative_ok);
 				if (!negative_ok)
 					failures++;
 
 				libp2p_err_t remove_rc =
-					libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, &failure_peer);
+					libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, failure_peer);
 				int remove_ok = (remove_rc == LIBP2P_ERR_OK);
 				print_result("gossipsub_score_failure_penalty_remove", remove_ok);
 				if (!remove_ok)
 					failures++;
 
-				double score_after = libp2p_gossipsub__peer_get_score(gs, &failure_peer, NULL);
+				double score_after = libp2p_gossipsub__peer_get_score(gs, failure_peer, NULL);
 				int penalty_sticky = (score_after < score_before - 0.4);
 				print_result("gossipsub_score_failure_penalty_sticky", penalty_sticky);
 				if (!penalty_sticky)
 					failures++;
 			}
 
-			(void)libp2p_gossipsub__peer_clear_sendq(gs, &failure_peer);
-			(void)libp2p_gossipsub__peer_set_connected(gs, &failure_peer, 0);
+			(void)libp2p_gossipsub__peer_clear_sendq(gs, failure_peer);
+			(void)libp2p_gossipsub__peer_set_connected(gs, failure_peer, 0);
 		}
 
 		if (subscribe_ok)
@@ -653,7 +652,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 		}
 
 		if (peer_ok)
-			peer_id_free(&failure_peer);
+			peer_id_free(failure_peer);
 	}
 
 	{
@@ -703,7 +702,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 		}
 
 		const char *peer_str = "12D3KooWR4hrfaGHadzZmuywckcUPMfELzUhY4JiuYxazJJQdky3";
-		peer_id_t invalid_peer = {0};
+		peer_id_t *invalid_peer = NULL;
 		int peer_ok = 0;
 		if (subscribe_ok)
 			peer_ok = setup_gossip_peer(gs, topic_name, peer_str, &invalid_peer);
@@ -713,7 +712,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 
 		if (subscribe_ok && peer_ok)
 		{
-			(void)libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, &invalid_peer, 1);
+			(void)libp2p_gossipsub__topic_mesh_add_peer(gs, topic_name, invalid_peer, 1);
 
 			const uint8_t payload[] = {0xDE, 0xAD, 0xBE, 0xEF};
 			const uint8_t seqno[] = {0x11, 0x22, 0x33, 0x44};
@@ -721,7 +720,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 				.topic = {.struct_size = sizeof(invalid_msg.topic), .topic = topic_name},
 				.data = payload,
 				.data_len = sizeof(payload),
-				.from = &invalid_peer,
+				.from = invalid_peer,
 				.seqno = seqno,
 				.seqno_len = sizeof(seqno),
 				.raw_message = NULL,
@@ -738,7 +737,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 			if (encode_ok)
 			{
 				libp2p_err_t inj_rc =
-					libp2p_gossipsub__inject_frame(gs, &invalid_peer, frame, frame_len);
+					libp2p_gossipsub__inject_frame(gs, invalid_peer, frame, frame_len);
 				int inject_ok = (inj_rc == LIBP2P_ERR_OK);
 				print_result("gossipsub_score_invalid_inject", inject_ok);
 				if (!inject_ok)
@@ -746,7 +745,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 				else
 				{
 					usleep(10000);
-					double score = libp2p_gossipsub__peer_get_score(gs, &invalid_peer, NULL);
+					double score = libp2p_gossipsub__peer_get_score(gs, invalid_peer, NULL);
 					int score_ok = (score < 0.0);
 					print_result("gossipsub_score_invalid_negative", score_ok);
 					if (!score_ok)
@@ -757,9 +756,9 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 			if (frame)
 				free(frame);
 
-			(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, &invalid_peer);
-			(void)libp2p_gossipsub__peer_clear_sendq(gs, &invalid_peer);
-			(void)libp2p_gossipsub__peer_set_connected(gs, &invalid_peer, 0);
+			(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, topic_name, invalid_peer);
+			(void)libp2p_gossipsub__peer_clear_sendq(gs, invalid_peer);
+			(void)libp2p_gossipsub__peer_set_connected(gs, invalid_peer, 0);
 		}
 
 		if (validator_handle)
@@ -791,7 +790,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 		}
 
 		if (peer_ok)
-			peer_id_free(&invalid_peer);
+			peer_id_free(invalid_peer);
 	}
 
 	{
@@ -831,7 +830,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 		if (!runtime_sub_ok)
 			failures++;
 
-		peer_id_t runtime_peer = {0};
+		peer_id_t *runtime_peer = NULL;
 		int runtime_peer_ok =
 			runtime_sub_ok && setup_gossip_peer(gs, runtime_topic, runtime_peer_str, &runtime_peer);
 		print_result("gossipsub_runtime_update_peer_setup", runtime_peer_ok);
@@ -843,7 +842,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 		if (runtime_sub_ok && runtime_peer_ok)
 		{
 			libp2p_err_t mesh_rc =
-				libp2p_gossipsub__topic_mesh_add_peer(gs, runtime_topic, &runtime_peer, 1);
+				libp2p_gossipsub__topic_mesh_add_peer(gs, runtime_topic, runtime_peer, 1);
 			int mesh_ok = (mesh_rc == LIBP2P_ERR_OK);
 			print_result("gossipsub_runtime_update_mesh_join", mesh_ok);
 			if (!mesh_ok)
@@ -854,7 +853,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 				(void)libp2p_gossipsub__heartbeat(gs);
 				usleep(20000);
 				(void)libp2p_gossipsub__heartbeat(gs);
-				double initial_score = libp2p_gossipsub__peer_get_score(gs, &runtime_peer, NULL);
+				double initial_score = libp2p_gossipsub__peer_get_score(gs, runtime_peer, NULL);
 				int initial_positive = (initial_score > 0.0);
 				print_result("gossipsub_runtime_update_initial_score", initial_positive);
 				if (!initial_positive)
@@ -874,7 +873,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 				if (!boost_ok)
 					failures++;
 
-				double boosted_score = libp2p_gossipsub__peer_get_score(gs, &runtime_peer, NULL);
+				double boosted_score = libp2p_gossipsub__peer_get_score(gs, runtime_peer, NULL);
 				int boosted_higher = (boosted_score > initial_score * 1.5);
 				print_result("gossipsub_runtime_update_score_increased", boosted_higher);
 				if (!boosted_higher)
@@ -891,23 +890,23 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 				if (!clear_ok)
 					failures++;
 
-				double cleared_score = libp2p_gossipsub__peer_get_score(gs, &runtime_peer, NULL);
+				double cleared_score = libp2p_gossipsub__peer_get_score(gs, runtime_peer, NULL);
 				int cleared_zero = (cleared_score > -1e-6 && cleared_score < 1e-6);
 				print_result("gossipsub_runtime_update_score_cleared", cleared_zero);
 				if (!cleared_zero)
 					failures++;
 
 				(void)libp2p_gossipsub__heartbeat(gs);
-				double cleared_post_tick = libp2p_gossipsub__peer_get_score(gs, &runtime_peer, NULL);
+				double cleared_post_tick = libp2p_gossipsub__peer_get_score(gs, runtime_peer, NULL);
 				int cleared_stable = (cleared_post_tick > -1e-6 && cleared_post_tick < 1e-6);
 				print_result("gossipsub_runtime_update_score_stable", cleared_stable);
 				if (!cleared_stable)
 					failures++;
 			}
 
-			(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, runtime_topic, &runtime_peer);
-			(void)libp2p_gossipsub__peer_clear_sendq(gs, &runtime_peer);
-			(void)libp2p_gossipsub__peer_set_connected(gs, &runtime_peer, 0);
+			(void)libp2p_gossipsub__topic_mesh_remove_peer(gs, runtime_topic, runtime_peer);
+			(void)libp2p_gossipsub__peer_clear_sendq(gs, runtime_peer);
+			(void)libp2p_gossipsub__peer_set_connected(gs, runtime_peer, 0);
 		}
 
 		if (runtime_sub_ok)
@@ -925,7 +924,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 		}
 
 		if (runtime_peer_ok)
-			peer_id_free(&runtime_peer);
+			peer_id_free(runtime_peer);
 	}
 
 	{
@@ -942,7 +941,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 			failures++;
 
 		const char *peer_str = "12D3KooWJMCZpZGsGWpRieyU7gnaNmJKbnHiKK4xqSSdoRRt9P5r";
-		peer_id_t spam_peer = {0};
+		peer_id_t *spam_peer = NULL;
 		int peer_ok = 0;
 		if (subscribe_ok)
 			peer_ok = setup_gossip_peer(gs, topic_name, peer_str, &spam_peer);
@@ -954,32 +953,32 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 
 		if (subscribe_ok && peer_ok)
 		{
-			libp2p_err_t reset_app_rc = libp2p_gossipsub_set_peer_application_score(gs, &spam_peer, 0.0);
+			libp2p_err_t reset_app_rc = libp2p_gossipsub_set_peer_application_score(gs, spam_peer, 0.0);
 			int reset_app_ok = (reset_app_rc == LIBP2P_ERR_OK);
 			print_result("gossipsub_score_ihave_penalty_reset_app", reset_app_ok);
 			if (!reset_app_ok)
 				failures++;
 
-			libp2p_err_t reset_pen_rc = libp2p_gossipsub_set_peer_behaviour_penalty(gs, &spam_peer, 0.0);
+			libp2p_err_t reset_pen_rc = libp2p_gossipsub_set_peer_behaviour_penalty(gs, spam_peer, 0.0);
 			int reset_pen_ok = (reset_pen_rc == LIBP2P_ERR_OK);
 			print_result("gossipsub_score_ihave_penalty_reset_penalty", reset_pen_ok);
 			if (!reset_pen_ok)
 				failures++;
 
-			libp2p_err_t override_rc = libp2p_gossipsub__peer_set_score(gs, &spam_peer, 0.0);
+			libp2p_err_t override_rc = libp2p_gossipsub__peer_set_score(gs, spam_peer, 0.0);
 			int override_reset_ok = (override_rc == LIBP2P_ERR_OK);
 			print_result("gossipsub_score_ihave_penalty_override_reset", override_reset_ok);
 			if (!override_reset_ok)
 				failures++;
 
-			libp2p_err_t clear_override_rc = libp2p_gossipsub__peer_clear_score_override(gs, &spam_peer);
+			libp2p_err_t clear_override_rc = libp2p_gossipsub__peer_clear_score_override(gs, spam_peer);
 			int override_clear_ok = (clear_override_rc == LIBP2P_ERR_OK);
 			print_result("gossipsub_score_ihave_penalty_override_clear", override_clear_ok);
 			if (!override_clear_ok)
 				failures++;
 
 			double expected_penalty = env->cfg.ihave_spam_penalty;
-			double initial_score = libp2p_gossipsub__peer_get_score(gs, &spam_peer, NULL);
+			double initial_score = libp2p_gossipsub__peer_get_score(gs, spam_peer, NULL);
 			int initial_ok = (initial_score > -1e-6 && initial_score < 1e-6);
 			print_result("gossipsub_score_ihave_penalty_initial", initial_ok);
 			if (!initial_ok)
@@ -1009,7 +1008,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 					break;
 				}
 
-				libp2p_err_t inj_rc = libp2p_gossipsub__inject_frame(gs, &spam_peer, frame, frame_len);
+				libp2p_err_t inj_rc = libp2p_gossipsub__inject_frame(gs, spam_peer, frame, frame_len);
 				free(frame);
 				int inj_ok = (inj_rc == LIBP2P_ERR_OK);
 				char inj_name[64];
@@ -1023,7 +1022,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 
 				usleep(10000);
 
-				double score = libp2p_gossipsub__peer_get_score(gs, &spam_peer, NULL);
+				double score = libp2p_gossipsub__peer_get_score(gs, spam_peer, NULL);
 				if (i < 2)
 				{
 					int pre_penalty_ok = (score > -1e-6 && score < 1e-6);
@@ -1048,8 +1047,8 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 				}
 			}
 
-			(void)libp2p_gossipsub__peer_clear_sendq(gs, &spam_peer);
-			(void)libp2p_gossipsub__peer_set_connected(gs, &spam_peer, 0);
+			(void)libp2p_gossipsub__peer_clear_sendq(gs, spam_peer);
+			(void)libp2p_gossipsub__peer_set_connected(gs, spam_peer, 0);
 		}
 
 		if (subscribe_ok)
@@ -1067,7 +1066,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 		}
 
 		if (peer_ok)
-			peer_id_free(&spam_peer);
+			peer_id_free(spam_peer);
 	}
 
 	{
@@ -1084,7 +1083,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 			failures++;
 
 		const char *peer_str = "12D3KooWDGnJ9cYVbS1oFNsM1PYTR1eA6AAquuZqPtSg1xMkFk3d";
-		peer_id_t promise_peer = {0};
+		peer_id_t *promise_peer = NULL;
 		int peer_ok = 0;
 		if (subscribe_ok)
 			peer_ok = setup_gossip_peer(gs, topic_name, peer_str, &promise_peer);
@@ -1109,7 +1108,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 			else
 			{
 				libp2p_err_t inj_rc =
-					libp2p_gossipsub__inject_frame(gs, &promise_peer, ihave_frame, ihave_len);
+					libp2p_gossipsub__inject_frame(gs, promise_peer, ihave_frame, ihave_len);
 				int inj_ok = (inj_rc == LIBP2P_ERR_OK);
 				print_result("gossipsub_spam_promise_inject", inj_ok);
 				if (!inj_ok)
@@ -1117,7 +1116,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 				free(ihave_frame);
 			}
 
-			size_t queue_len = libp2p_gossipsub__peer_sendq_len(gs, &promise_peer);
+			size_t queue_len = libp2p_gossipsub__peer_sendq_len(gs, promise_peer);
 			int iwant_sent = (queue_len >= 1);
 			print_result("gossipsub_spam_promise_iwant_sent", iwant_sent);
 			if (!iwant_sent)
@@ -1126,7 +1125,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 			uint8_t *send_frame = NULL;
 			size_t send_len = 0;
 			libp2p_err_t pop_rc =
-				libp2p_gossipsub__peer_pop_sendq(gs, &promise_peer, &send_frame, &send_len);
+				libp2p_gossipsub__peer_pop_sendq(gs, promise_peer, &send_frame, &send_len);
 			int pop_ok = (pop_rc == LIBP2P_ERR_OK);
 			print_result("gossipsub_spam_promise_pop", pop_ok);
 			if (!pop_ok)
@@ -1134,7 +1133,7 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 			if (send_frame)
 				free(send_frame);
 
-			double initial_score = libp2p_gossipsub__peer_get_score(gs, &promise_peer, NULL);
+			double initial_score = libp2p_gossipsub__peer_get_score(gs, promise_peer, NULL);
 			int initial_ok = (initial_score > -1e-6 && initial_score < 1e-6);
 			print_result("gossipsub_spam_promise_initial_score", initial_ok);
 			if (!initial_ok)
@@ -1148,14 +1147,14 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 			if (!hb_ok)
 				failures++;
 
-			double after_score = libp2p_gossipsub__peer_get_score(gs, &promise_peer, NULL);
+			double after_score = libp2p_gossipsub__peer_get_score(gs, promise_peer, NULL);
 			int penalty_applied = (after_score < -0.5);
 			print_result("gossipsub_spam_promise_penalty", penalty_applied);
 			if (!penalty_applied)
 				failures++;
 
-			(void)libp2p_gossipsub__peer_clear_sendq(gs, &promise_peer);
-			(void)libp2p_gossipsub__peer_set_connected(gs, &promise_peer, 0);
+			(void)libp2p_gossipsub__peer_clear_sendq(gs, promise_peer);
+			(void)libp2p_gossipsub__peer_set_connected(gs, promise_peer, 0);
 		}
 
 		if (subscribe_ok)
@@ -1173,15 +1172,15 @@ int gossipsub_service_run_scoring_tests(gossipsub_service_test_env_t *env)
 		}
 
 		if (peer_ok)
-			peer_id_free(&promise_peer);
+			peer_id_free(promise_peer);
 	}
 
 	{
 		const char *explicit_peer_str = "12D3KooWL9qw9QdCsiPUQXGWxZhwivKar35CFYuU9B9kavHuV2XZ";
 		const char *mesh_peer_str = "12D3KooWL41axLhXgML3zbxTDkVxFvtz7ZzZWtH1yurVpbkWueMH";
 		const char *explicit_topic_name = "explicit/test/topic";
-		peer_id_t explicit_peer = {0};
-		peer_id_t mesh_peer = {0};
+		peer_id_t *explicit_peer = NULL;
+		peer_id_t *mesh_peer = NULL;
 		int explicit_peer_ok = (peer_id_new_from_text(explicit_peer_str, &explicit_peer) == PEER_ID_OK);
 		int mesh_peer_ok = (peer_id_new_from_text(mesh_peer_str, &mesh_peer) == PEER_ID_OK);
 	}

--- a/tests/protocol/gossipsub/test_gossipsub_service_setup.c
+++ b/tests/protocol/gossipsub/test_gossipsub_service_setup.c
@@ -47,24 +47,22 @@ int gossipsub_service_run_setup(gossipsub_service_test_env_t *env)
 	env->host = host;
 
 	const char *config_peer_str = "12D3KooWL9qw9QdCsiPUQXGWxZhwivKar35CFYuU9B9kavHuV2XZ";
-	peer_id_t config_peer = {0};
+	peer_id_t *config_peer = NULL;
 	int config_peer_ok = (peer_id_new_from_text(config_peer_str, &config_peer) == PEER_ID_OK);
 	print_result("gossipsub_explicit_config_peer_id", config_peer_ok);
 	if (!config_peer_ok)
 	{
 		failures++;
-		memset(&env->config_peer, 0, sizeof(env->config_peer));
+		env->config_peer = NULL;
 		env->config_peer_ok = 0;
 	}
 	else
 	{
 		env->config_peer = config_peer;
-		config_peer.bytes = NULL;
-		config_peer.size = 0;
 		env->config_peer_ok = 1;
 		env->config_addrs[0] = "/ip4/127.0.0.1/tcp/7001";
 		env->cfg_explicit_peer.struct_size = sizeof(env->cfg_explicit_peer);
-		env->cfg_explicit_peer.peer = &env->config_peer;
+		env->cfg_explicit_peer.peer = env->config_peer;
 		env->cfg_explicit_peer.addresses = env->config_addrs;
 		env->cfg_explicit_peer.address_count = 1;
 	}
@@ -182,7 +180,7 @@ int gossipsub_service_run_setup(gossipsub_service_test_env_t *env)
 		size_t seeded_len = 0;
 		int peerstore_ok = (host->peerstore != NULL);
 		if (peerstore_ok)
-			peerstore_ok = (libp2p_peerstore_get_addrs(host->peerstore, &env->config_peer, &seeded,
+			peerstore_ok = (libp2p_peerstore_get_addrs(host->peerstore, env->config_peer, &seeded,
 								   &seeded_len) == 0);
 		int seeded_available = (peerstore_ok && seeded_len >= 1);
 		print_result("gossipsub_explicit_config_seeded_peerstore", seeded_available);
@@ -279,7 +277,7 @@ int gossipsub_service_run_setup(gossipsub_service_test_env_t *env)
 		atomic_store(&g_async_called, 0);
 
 		const char *test_peer_str = "12D3KooWQ7W3zfBDSSY5YTbSsfXCMVvjJAnYXhYzu3PV6PvJkU8E";
-		peer_id_t self_peer = {0};
+		peer_id_t *self_peer = NULL;
 		int peer_ok = (peer_id_new_from_text(test_peer_str, &self_peer) == PEER_ID_OK);
 		libp2p_err_t enc_err = LIBP2P_ERR_INTERNAL;
 		libp2p_err_t inj_err = LIBP2P_ERR_INTERNAL;
@@ -292,7 +290,7 @@ int gossipsub_service_run_setup(gossipsub_service_test_env_t *env)
 				.topic = {.struct_size = sizeof(inbound_msg.topic), .topic = "test/topic"},
 				.data = inbound_payload,
 				.data_len = sizeof(inbound_payload),
-				.from = &self_peer,
+				.from = self_peer,
 				.seqno = inbound_seqno,
 				.seqno_len = sizeof(inbound_seqno),
 				.raw_message = NULL,
@@ -303,7 +301,7 @@ int gossipsub_service_run_setup(gossipsub_service_test_env_t *env)
 			enc_err = libp2p_gossipsub_rpc_encode_publish(&inbound_msg, &encoded, &encoded_len);
 			if (enc_err == LIBP2P_ERR_OK && encoded && encoded_len)
 			{
-				inj_err = libp2p_gossipsub__inject_frame(gs, &self_peer, encoded, encoded_len);
+				inj_err = libp2p_gossipsub__inject_frame(gs, self_peer, encoded, encoded_len);
 				if (inj_err == LIBP2P_ERR_OK)
 				{
 					for (int i = 0; i < 200 && atomic_load_explicit(&g_async_called,
@@ -339,7 +337,7 @@ int gossipsub_service_run_setup(gossipsub_service_test_env_t *env)
 			failures++;
 
 		if (peer_ok)
-			peer_id_free(&self_peer);
+			peer_id_free(self_peer);
 	}
 	else
 	{

--- a/tests/protocol/gossipsub/test_gossipsub_service_subscription_mesh.c
+++ b/tests/protocol/gossipsub/test_gossipsub_service_subscription_mesh.c
@@ -12,7 +12,7 @@ int gossipsub_service_run_subscription_mesh_tests(gossipsub_service_test_env_t *
 	{
 		const char *subscription_peer_str = "12D3KooWFnNMhkbi8d4Ryh5UCnmAeUXUQCA2PMAMFLyLLKkR6aom";
 		const char *subscription_topic = "test/topic";
-		peer_id_t subscription_peer = {0};
+		peer_id_t *subscription_peer = NULL;
 		int sub_peer_ok = (peer_id_new_from_text(subscription_peer_str, &subscription_peer) == PEER_ID_OK);
 		print_result("gossipsub_subscription_peer_id", sub_peer_ok);
 		if (!sub_peer_ok)
@@ -27,11 +27,11 @@ int gossipsub_service_run_subscription_mesh_tests(gossipsub_service_test_env_t *
 			size_t frame_len = 0;
 			sub_enc_err = encode_subscription_rpc(subscription_topic, 1, &frame, &frame_len);
 			if (sub_enc_err == LIBP2P_ERR_OK && frame && frame_len)
-				sub_inj_err = libp2p_gossipsub__inject_frame(gs, &subscription_peer, frame, frame_len);
+				sub_inj_err = libp2p_gossipsub__inject_frame(gs, subscription_peer, frame, frame_len);
 			if (frame)
 				free(frame);
 			subscription_recorded =
-				libp2p_gossipsub__peer_has_subscription(gs, &subscription_peer, subscription_topic);
+				libp2p_gossipsub__peer_has_subscription(gs, subscription_peer, subscription_topic);
 		}
 
 		print_result("gossipsub_subscription_rpc_encoded", sub_enc_err == LIBP2P_ERR_OK);
@@ -51,7 +51,7 @@ int gossipsub_service_run_subscription_mesh_tests(gossipsub_service_test_env_t *
 		if (subscription_recorded)
 		{
 			libp2p_err_t mesh_add_rc =
-				libp2p_gossipsub__topic_mesh_add_peer(gs, subscription_topic, &subscription_peer, 1);
+				libp2p_gossipsub__topic_mesh_add_peer(gs, subscription_topic, subscription_peer, 1);
 			mesh_add_ok = (mesh_add_rc == LIBP2P_ERR_OK);
 		}
 		print_result("gossipsub_mesh_add_subscribed_peer", mesh_add_ok);
@@ -69,10 +69,10 @@ int gossipsub_service_run_subscription_mesh_tests(gossipsub_service_test_env_t *
 			unsub_enc_err = encode_subscription_rpc(subscription_topic, 0, &frame, &frame_len);
 			if (unsub_enc_err == LIBP2P_ERR_OK && frame && frame_len)
 				unsub_inj_err =
-					libp2p_gossipsub__inject_frame(gs, &subscription_peer, frame, frame_len);
+					libp2p_gossipsub__inject_frame(gs, subscription_peer, frame, frame_len);
 			if (frame)
 				free(frame);
-			subscription_cleared = libp2p_gossipsub__peer_has_subscription(gs, &subscription_peer,
+			subscription_cleared = libp2p_gossipsub__peer_has_subscription(gs, subscription_peer,
 										       subscription_topic) == 0;
 			mesh_after_unsub = libp2p_gossipsub__topic_mesh_size(gs, subscription_topic);
 		}
@@ -96,14 +96,14 @@ int gossipsub_service_run_subscription_mesh_tests(gossipsub_service_test_env_t *
 			failures++;
 
 		if (sub_peer_ok)
-			peer_id_free(&subscription_peer);
+			peer_id_free(subscription_peer);
 	}
 
 	{
 		const char *peer1_str = "12D3KooWDbSkFwsij4BjjHfZxQqJ1zuvBABFqQ5uwSX6ZiUvUv9d";
 		const char *peer2_str = "12D3KooWN9oSkqZSS7Y7gsnAmfmNgmcByKYEzGyv1mCXN8vQiyTe";
-		peer_id_t mesh_peer1 = {0};
-		peer_id_t mesh_peer2 = {0};
+		peer_id_t *mesh_peer1 = NULL;
+		peer_id_t *mesh_peer2 = NULL;
 		int peer1_ok = (peer_id_new_from_text(peer1_str, &mesh_peer1) == PEER_ID_OK);
 		int peer2_ok = (peer_id_new_from_text(peer2_str, &mesh_peer2) == PEER_ID_OK);
 		int mesh_ids_ok = peer1_ok && peer2_ok;
@@ -113,7 +113,7 @@ int gossipsub_service_run_subscription_mesh_tests(gossipsub_service_test_env_t *
 
 		if (mesh_ids_ok)
 		{
-			err = libp2p_gossipsub__topic_mesh_add_peer(gs, "test/topic", &mesh_peer1, 1);
+			err = libp2p_gossipsub__topic_mesh_add_peer(gs, "test/topic", mesh_peer1, 1);
 			int mesh_add1_ok = (err == LIBP2P_ERR_OK);
 			print_result("gossipsub_mesh_add_peer1", mesh_add1_ok);
 			if (!mesh_add1_ok)
@@ -127,14 +127,14 @@ int gossipsub_service_run_subscription_mesh_tests(gossipsub_service_test_env_t *
 
 			int outbound_flag = -1;
 			uint64_t hb_ms = 0;
-			int contains1 = libp2p_gossipsub__topic_mesh_contains(gs, "test/topic", &mesh_peer1,
+			int contains1 = libp2p_gossipsub__topic_mesh_contains(gs, "test/topic", mesh_peer1,
 									      &outbound_flag, &hb_ms);
 			int contains1_ok = contains1 && outbound_flag == 1 && hb_ms > 0;
 			print_result("gossipsub_mesh_contains_peer1", contains1_ok);
 			if (!contains1_ok)
 				failures++;
 
-			err = libp2p_gossipsub__topic_mesh_add_peer(gs, "test/topic", &mesh_peer2, 0);
+			err = libp2p_gossipsub__topic_mesh_add_peer(gs, "test/topic", mesh_peer2, 0);
 			int mesh_add2_ok = (err == LIBP2P_ERR_OK);
 			print_result("gossipsub_mesh_add_peer2", mesh_add2_ok);
 			if (!mesh_add2_ok)
@@ -148,21 +148,21 @@ int gossipsub_service_run_subscription_mesh_tests(gossipsub_service_test_env_t *
 
 			outbound_flag = -1;
 			hb_ms = 0;
-			int contains2 = libp2p_gossipsub__topic_mesh_contains(gs, "test/topic", &mesh_peer2,
+			int contains2 = libp2p_gossipsub__topic_mesh_contains(gs, "test/topic", mesh_peer2,
 									      &outbound_flag, &hb_ms);
 			int contains2_ok = contains2 && outbound_flag == 0 && hb_ms > 0;
 			print_result("gossipsub_mesh_contains_peer2", contains2_ok);
 			if (!contains2_ok)
 				failures++;
 
-			err = libp2p_gossipsub__topic_mesh_remove_peer(gs, "test/topic", &mesh_peer1);
+			err = libp2p_gossipsub__topic_mesh_remove_peer(gs, "test/topic", mesh_peer1);
 			mesh_sz = libp2p_gossipsub__topic_mesh_size(gs, "test/topic");
 			int mesh_remove1_ok = (err == LIBP2P_ERR_OK) && mesh_sz == 1;
 			print_result("gossipsub_mesh_remove_peer1", mesh_remove1_ok);
 			if (!mesh_remove1_ok)
 				failures++;
 
-			err = libp2p_gossipsub_peering_remove(gs, &mesh_peer2);
+			err = libp2p_gossipsub_peering_remove(gs, mesh_peer2);
 			mesh_sz = libp2p_gossipsub__topic_mesh_size(gs, "test/topic");
 			int mesh_remove2_ok = (err == LIBP2P_ERR_OK) && mesh_sz == 0;
 			print_result("gossipsub_mesh_remove_peer2", mesh_remove2_ok);
@@ -171,14 +171,14 @@ int gossipsub_service_run_subscription_mesh_tests(gossipsub_service_test_env_t *
 		}
 
 		if (peer1_ok)
-			peer_id_free(&mesh_peer1);
+			peer_id_free(mesh_peer1);
 		if (peer2_ok)
-			peer_id_free(&mesh_peer2);
+			peer_id_free(mesh_peer2);
 	}
 
 	{
 		const char *fanout_peer_str = "12D3KooWJMCZpZGsGWpRieyU7gnaNmJKbnHiKK4xqSSdoRRt9P5r";
-		peer_id_t fanout_peer = {0};
+		peer_id_t *fanout_peer = NULL;
 		int fanout_peer_ok = (peer_id_new_from_text(fanout_peer_str, &fanout_peer) == PEER_ID_OK);
 		print_result("gossipsub_fanout_peer_id_created", fanout_peer_ok);
 		if (!fanout_peer_ok)
@@ -186,7 +186,7 @@ int gossipsub_service_run_subscription_mesh_tests(gossipsub_service_test_env_t *
 
 		if (fanout_peer_ok)
 		{
-			err = libp2p_gossipsub__topic_fanout_add_peer(gs, "fanout/topic", &fanout_peer, -1, 5000);
+			err = libp2p_gossipsub__topic_fanout_add_peer(gs, "fanout/topic", fanout_peer, -1, 5000);
 			int fanout_add_ok = (err == LIBP2P_ERR_OK);
 			print_result("gossipsub_fanout_add_peer", fanout_add_ok);
 			if (!fanout_add_ok)
@@ -200,7 +200,7 @@ int gossipsub_service_run_subscription_mesh_tests(gossipsub_service_test_env_t *
 
 			int outbound_flag = -1;
 			uint64_t last_publish_ms = 0;
-			int fanout_contains = libp2p_gossipsub__topic_fanout_contains(gs, "fanout/topic", &fanout_peer,
+			int fanout_contains = libp2p_gossipsub__topic_fanout_contains(gs, "fanout/topic", fanout_peer,
 										      &outbound_flag, &last_publish_ms);
 			int fanout_contains_ok = fanout_contains && last_publish_ms > 0;
 			print_result("gossipsub_fanout_contains_peer", fanout_contains_ok);
@@ -213,7 +213,7 @@ int gossipsub_service_run_subscription_mesh_tests(gossipsub_service_test_env_t *
 			if (!expire_ok)
 				failures++;
 
-			err = libp2p_gossipsub__topic_fanout_remove_peer(gs, "fanout/topic", &fanout_peer);
+			err = libp2p_gossipsub__topic_fanout_remove_peer(gs, "fanout/topic", fanout_peer);
 			fanout_sz = libp2p_gossipsub__topic_fanout_size(gs, "fanout/topic");
 			int fanout_remove_ok = (err == LIBP2P_ERR_OK) && fanout_sz == 0;
 			print_result("gossipsub_fanout_remove_peer", fanout_remove_ok);
@@ -222,7 +222,7 @@ int gossipsub_service_run_subscription_mesh_tests(gossipsub_service_test_env_t *
 		}
 
 		if (fanout_peer_ok)
-			peer_id_free(&fanout_peer);
+			peer_id_free(fanout_peer);
 	}
 
 	return failures;

--- a/tests/util/test_peerstore.c
+++ b/tests/util/test_peerstore.c
@@ -54,7 +54,7 @@ int main(void)
 		return 1;
 	}
 
-	peer_id_t pid = {0};
+	peer_id_t *pid = NULL;
 	if (peer_id_new_from_public_key_pb(pub_pb, pub_len, &pid) != PEER_ID_OK)
 	{
 		fprintf(stderr, "peer_id_new_from_public_key_pb failed\n");
@@ -72,7 +72,7 @@ int main(void)
 		goto out_err;
 	}
 
-	int rc = libp2p_peerstore_add_addr(ps, &pid, ma, 60 * 1000);
+	int rc = libp2p_peerstore_add_addr(ps, pid, ma, 60 * 1000);
 	print_result("peerstore_add_addr", rc == 0);
 	if (rc != 0)
 	{
@@ -81,7 +81,7 @@ int main(void)
 
 	const multiaddr_t **out_addrs = NULL;
 	size_t out_len = 0;
-	rc = libp2p_peerstore_get_addrs(ps, &pid, &out_addrs, &out_len);
+	rc = libp2p_peerstore_get_addrs(ps, pid, &out_addrs, &out_len);
 	int ok = (rc == 0 && out_len >= 1 && out_addrs != NULL);
 	print_result("peerstore_get_addrs", ok);
 	if (!ok)
@@ -107,14 +107,14 @@ int main(void)
 
 	/* Protocols set/get */
 	const char *protos[2] = {"/ipfs/id/1.0.0", "/ipfs/ping/1.0.0"};
-	rc = libp2p_peerstore_set_protocols(ps, &pid, protos, 2);
+	rc = libp2p_peerstore_set_protocols(ps, pid, protos, 2);
 	print_result("peerstore_set_protocols", rc == 0);
 	if (rc != 0)
 		failures++;
 
 	const char **got = NULL;
 	size_t got_len = 0;
-	rc = libp2p_peerstore_get_protocols(ps, &pid, &got, &got_len);
+	rc = libp2p_peerstore_get_protocols(ps, pid, &got, &got_len);
 	ok = (rc == 0 && got && got_len == 2);
 	print_result("peerstore_get_protocols", ok);
 	if (!ok)
@@ -130,7 +130,7 @@ int main(void)
 	libp2p_peerstore_free_protocols(got, got_len);
 
 	/* Public key store (no getter; just store should succeed) */
-	rc = libp2p_peerstore_set_public_key(ps, &pid, pub_pb, pub_len);
+	rc = libp2p_peerstore_set_public_key(ps, pid, pub_pb, pub_len);
 	print_result("peerstore_set_public_key", rc == 0);
 	if (rc != 0)
 		failures++;
@@ -138,7 +138,7 @@ int main(void)
 	/* Public key getter and equality check */
 	uint8_t *got_pb = NULL;
 	size_t got_pb_len = 0;
-	rc = libp2p_peerstore_get_public_key(ps, &pid, &got_pb, &got_pb_len);
+	rc = libp2p_peerstore_get_public_key(ps, pid, &got_pb, &got_pb_len);
 	int okpk = (rc == 0 && got_pb && got_pb_len == pub_len && memcmp(got_pb, pub_pb, pub_len) == 0);
 	print_result("peerstore_get_public_key", okpk);
 	if (!okpk)
@@ -147,14 +147,14 @@ int main(void)
 
 	multiaddr_free(ma);
 	free(pub_pb);
-	peer_id_free(&pid);
+	peer_id_free(pid);
 	libp2p_peerstore_free(ps);
 
 	return failures ? 1 : 0;
 
 out_err:
 	free(pub_pb);
-	peer_id_free(&pid);
+	peer_id_free(pid);
 	libp2p_peerstore_free(ps);
 	return 1;
 }


### PR DESCRIPTION
The main branch is currently not building because the tests haven't been updated to the new opaque `peer_id_t`. I had Claude go through the tests and update them, just so I could build the code, and I thought this would be useful as a PR.
All the tests are passing, except for `Testprotocol_gossipsub`, but it looks like it wasn't passing before the change either, at least on my machine (I checked with commit 155111500306d906c4aae95e77d1442cbfec57b6).