### PR TITLE
Fix test_peerstore build on Ubuntu 24.04 / gcc-14

### DIFF
--- a/tests/util/test_peerstore.c
+++ b/tests/util/test_peerstore.c
@@ -54,7 +54,7 @@ int main(void)
 		return 1;
 	}
 
-	peer_id_t pid = {0};
+	peer_id_t *pid = NULL;
 	if (peer_id_new_from_public_key_pb(pub_pb, pub_len, &pid) != PEER_ID_OK)
 	{
 		fprintf(stderr, "peer_id_new_from_public_key_pb failed\n");
@@ -72,7 +72,7 @@ int main(void)
 		goto out_err;
 	}
 
-	int rc = libp2p_peerstore_add_addr(ps, &pid, ma, 60 * 1000);
+	int rc = libp2p_peerstore_add_addr(ps, pid, ma, 60 * 1000);
 	print_result("peerstore_add_addr", rc == 0);
 	if (rc != 0)
 	{
@@ -81,7 +81,7 @@ int main(void)
 
 	const multiaddr_t **out_addrs = NULL;
 	size_t out_len = 0;
-	rc = libp2p_peerstore_get_addrs(ps, &pid, &out_addrs, &out_len);
+	rc = libp2p_peerstore_get_addrs(ps, pid, &out_addrs, &out_len);
 	int ok = (rc == 0 && out_len >= 1 && out_addrs != NULL);
 	print_result("peerstore_get_addrs", ok);
 	if (!ok)
@@ -107,14 +107,14 @@ int main(void)
 
 	/* Protocols set/get */
 	const char *protos[2] = {"/ipfs/id/1.0.0", "/ipfs/ping/1.0.0"};
-	rc = libp2p_peerstore_set_protocols(ps, &pid, protos, 2);
+	rc = libp2p_peerstore_set_protocols(ps, pid, protos, 2);
 	print_result("peerstore_set_protocols", rc == 0);
 	if (rc != 0)
 		failures++;
 
 	const char **got = NULL;
 	size_t got_len = 0;
-	rc = libp2p_peerstore_get_protocols(ps, &pid, &got, &got_len);
+	rc = libp2p_peerstore_get_protocols(ps, pid, &got, &got_len);
 	ok = (rc == 0 && got && got_len == 2);
 	print_result("peerstore_get_protocols", ok);
 	if (!ok)
@@ -130,7 +130,7 @@ int main(void)
 	libp2p_peerstore_free_protocols(got, got_len);
 
 	/* Public key store (no getter; just store should succeed) */
-	rc = libp2p_peerstore_set_public_key(ps, &pid, pub_pb, pub_len);
+	rc = libp2p_peerstore_set_public_key(ps, pid, pub_pb, pub_len);
 	print_result("peerstore_set_public_key", rc == 0);
 	if (rc != 0)
 		failures++;
@@ -138,7 +138,7 @@ int main(void)
 	/* Public key getter and equality check */
 	uint8_t *got_pb = NULL;
 	size_t got_pb_len = 0;
-	rc = libp2p_peerstore_get_public_key(ps, &pid, &got_pb, &got_pb_len);
+	rc = libp2p_peerstore_get_public_key(ps, pid, &got_pb, &got_pb_len);
 	int okpk = (rc == 0 && got_pb && got_pb_len == pub_len && memcmp(got_pb, pub_pb, pub_len) == 0);
 	print_result("peerstore_get_public_key", okpk);
 	if (!okpk)
@@ -147,14 +147,14 @@ int main(void)
 
 	multiaddr_free(ma);
 	free(pub_pb);
-	peer_id_free(&pid);
+	peer_id_free(pid);
 	libp2p_peerstore_free(ps);
 
 	return failures ? 1 : 0;
 
 out_err:
 	free(pub_pb);
-	peer_id_free(&pid);
+	peer_id_free(pid);
 	libp2p_peerstore_free(ps);
 	return 1;
 }


### PR DESCRIPTION
## Summary
- `tests/util/test_peerstore.c` declared `peer_id_t pid = {0};`, but `peer_id_t` is a forward-declared opaque struct in [include/peer_id/peer_id.h](../blob/main/include/peer_id/peer_id.h) — this fails to compile on Ubuntu 24.04 with gcc-14:
  ```
  error: variable 'pid' has initializer but incomplete type
  error: storage size of 'pid' isn't known
  ```
- Updated the test to use the opaque pointer API used elsewhere in the suite (e.g. `tests/protocol/quic/test_quic_stream_loopback.c`): `peer_id_t *pid = NULL;` allocated by `peer_id_new_from_public_key_pb`, dropped `&` at call sites, freed via `peer_id_free(pid)`.
- Reported by B1smuth on Discord.

## Test plan
- [x] Clean build + run on Ubuntu 24.04 Docker container with gcc-14 — `test_peerstore` compiles and all 8 assertions pass.
- [ ] CI green on fast + full lanes.